### PR TITLE
Fix PartComponent -> Module rename for KSA v2026.2.35.3667

### DIFF
--- a/AdvancedFlightComputer/Features/AutoStage/AutoStage.cs
+++ b/AdvancedFlightComputer/Features/AutoStage/AutoStage.cs
@@ -192,9 +192,9 @@ static class Patch_Vehicle_IsFlightComputerDisabled
 ///   Frame N:   Staging happens here. PrepareWorker snapshots the new engine
 ///              states (IsActive=true, IsPropellantAvailable=false).
 ///   N -> N+1 job: UpdateBurnTarget reads IsPropellantAvailable=false, sets
-///              BurnMode=Manual. Then UpdatePartComponents/Rocket.UpdateRockets
+///              BurnMode=Manual. Then UpdateModules/Rocket.UpdateRockets
 ///              checks propellant and sets IsPropellantAvailable=true in the
-///              state buffer. (ComputeControl runs before UpdatePartComponents.)
+///              state buffer. (ComputeControl runs before UpdateModules.)
 ///   Frame N+1: ApplyResults writes BurnMode=Manual AND the updated engine
 ///              states (IsPropellantAvailable=true) back to the Vehicle.
 ///              Grace forces BurnMode=Auto. PrepareWorker now snapshots

--- a/AdvancedFlightComputer/Features/StageInfo/StageAnalyzer.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageAnalyzer.cs
@@ -267,7 +267,7 @@ public static class StageAnalyzer
         ReadOnlySpan<Part> parts = stage.Parts;
         for (int pi = 0; pi < parts.Length; pi++)
         {
-            Span<EngineController> engines = parts[pi].Components.Get<EngineController>();
+            Span<EngineController> engines = parts[pi].Modules.Get<EngineController>();
             for (int ei = 0; ei < engines.Length; ei++)
             {
                 if (engines[ei].IsActive)
@@ -289,7 +289,7 @@ public static class StageAnalyzer
 
         for (int pi = 0; pi < parts.Length; pi++)
         {
-            Span<EngineController> engines = parts[pi].Components.Get<EngineController>();
+            Span<EngineController> engines = parts[pi].Modules.Get<EngineController>();
             for (int ei = 0; ei < engines.Length; ei++)
             {
                 EngineController engine = engines[ei];
@@ -513,7 +513,7 @@ public static class StageAnalyzer
         for (int pi = 0; pi < parts.Length; pi++)
         {
             Part part = parts[pi];
-            if (!part.Components.HasAny<Decoupler>())
+            if (!part.Modules.HasAny<Decoupler>())
                 continue;
 
             float subtreeMass = CollectSubtreeMass(
@@ -566,17 +566,17 @@ public static class StageAnalyzer
         ReadOnlySpan<MoleState> moleStates,
         HashSet<ulong> fuelClaimedTankIds)
     {
-        float mass = SumComponentMass(part.Components, moleStates, fuelClaimedTankIds);
+        float mass = SumComponentMass(part.Modules, moleStates, fuelClaimedTankIds);
 
         ReadOnlySpan<Part> subParts = part.SubParts;
         for (int i = 0; i < subParts.Length; i++)
-            mass += SumComponentMass(subParts[i].Components, moleStates, fuelClaimedTankIds);
+            mass += SumComponentMass(subParts[i].Modules, moleStates, fuelClaimedTankIds);
 
         return mass;
     }
 
     private static float SumComponentMass(
-        PartComponentList components,
+        ModuleList components,
         ReadOnlySpan<MoleState> moleStates,
         HashSet<ulong> fuelClaimedTankIds)
     {


### PR DESCRIPTION
## Summary

- Game v2026.2.35.3667 renamed `PartComponent` to `Module` and all related types/properties

Closes #11