### PR TITLE
Add per-feature debug toggles and Stopwatch diagnostics

### DIFF
--- a/AdvancedFlightComputer/AdvancedFlightComputer.csproj
+++ b/AdvancedFlightComputer/AdvancedFlightComputer.csproj
@@ -45,7 +45,7 @@
     </None>
   </ItemGroup>
 
-  <Target Name="CopyToMods" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
+  <Target Name="CopyToMods" AfterTargets="Build">
     <PropertyGroup>
       <ModDir>..\..\Kitten Space Agency\Content\AdvancedFlightComputer\</ModDir>
     </PropertyGroup>

--- a/AdvancedFlightComputer/Core/DebugConfig.cs
+++ b/AdvancedFlightComputer/Core/DebugConfig.cs
@@ -1,0 +1,25 @@
+namespace AdvancedFlightComputer.Core;
+
+/// <summary>
+/// Per-feature debug toggles. In DEBUG builds all flags default to true;
+/// set individual flags to false at the top of this file to reduce log
+/// noise while debugging a specific feature. In Release builds everything
+/// is off and the JIT eliminates dead branches.
+/// </summary>
+static class DebugConfig
+{
+#if DEBUG
+    public static bool HyperbolicTargets = true;
+    public static bool AutoStage = true;
+    public static bool StageInfo = true;
+    public static bool Performance = true;
+#else
+    public static bool HyperbolicTargets = false;
+    public static bool AutoStage = false;
+    public static bool StageInfo = false;
+    public static bool Performance = false;
+#endif
+
+    public static bool Any =>
+        HyperbolicTargets || AutoStage || StageInfo || Performance;
+}

--- a/AdvancedFlightComputer/Core/PerfTracker.cs
+++ b/AdvancedFlightComputer/Core/PerfTracker.cs
@@ -1,0 +1,106 @@
+#if DEBUG
+using System.Diagnostics;
+using System.Globalization;
+using Brutal.Logging;
+
+namespace AdvancedFlightComputer.Core;
+
+/// <summary>
+/// Lightweight per-method Stopwatch accumulator for debug builds.
+/// Tracks call count, total/min/max elapsed ticks and reports a
+/// summary to the log every <see cref="ReportIntervalSeconds"/> seconds.
+///
+/// Usage in measured methods:
+/// <code>
+/// #if DEBUG
+/// long perfStart = DebugConfig.Performance ? Stopwatch.GetTimestamp() : 0;
+/// #endif
+/// // ... work ...
+/// #if DEBUG
+/// if (DebugConfig.Performance)
+///     PerfTracker.Record("MethodName", Stopwatch.GetTimestamp() - perfStart);
+/// #endif
+/// </code>
+/// </summary>
+static class PerfTracker
+{
+    private const double ReportIntervalSeconds = 5.0;
+
+    private static readonly Dictionary<string, PerfData> _entries = new();
+    private static readonly List<string> _orderedKeys = new();
+    private static long _lastReportTimestamp = Stopwatch.GetTimestamp();
+
+    private struct PerfData
+    {
+        public int Count;
+        public long TotalTicks;
+        public long MinTicks;
+        public long MaxTicks;
+    }
+
+    public static void Record(string name, long elapsedTicks)
+    {
+        if (_entries.TryGetValue(name, out var data))
+        {
+            data.Count++;
+            data.TotalTicks += elapsedTicks;
+            if (elapsedTicks < data.MinTicks) data.MinTicks = elapsedTicks;
+            if (elapsedTicks > data.MaxTicks) data.MaxTicks = elapsedTicks;
+            _entries[name] = data;
+        }
+        else
+        {
+            _entries[name] = new PerfData
+            {
+                Count = 1,
+                TotalTicks = elapsedTicks,
+                MinTicks = elapsedTicks,
+                MaxTicks = elapsedTicks
+            };
+            _orderedKeys.Add(name);
+        }
+
+        MaybeReport();
+    }
+
+    private static void MaybeReport()
+    {
+        long now = Stopwatch.GetTimestamp();
+        double elapsed = (now - _lastReportTimestamp) / (double)Stopwatch.Frequency;
+        if (elapsed < ReportIntervalSeconds)
+            return;
+
+        _lastReportTimestamp = now;
+
+        foreach (string key in _orderedKeys)
+        {
+            if (!_entries.TryGetValue(key, out var data) || data.Count == 0)
+                continue;
+
+            double avgMs = TicksToMs(data.TotalTicks / data.Count);
+            double minMs = TicksToMs(data.MinTicks);
+            double maxMs = TicksToMs(data.MaxTicks);
+
+            DefaultCategory.Log.Debug(string.Format(
+                CultureInfo.InvariantCulture,
+                "[AFC] Perf ({0:F1}s): {1} avg={2:F3}ms min={3:F3}ms max={4:F3}ms ({5} calls)",
+                elapsed, key, avgMs, minMs, maxMs, data.Count));
+        }
+
+        _entries.Clear();
+        _orderedKeys.Clear();
+    }
+
+    private static double TicksToMs(long ticks)
+    {
+        return ticks * 1000.0 / Stopwatch.Frequency;
+    }
+
+    public static void Reset()
+    {
+        _entries.Clear();
+        _orderedKeys.Clear();
+        _lastReportTimestamp = Stopwatch.GetTimestamp();
+    }
+}
+#endif

--- a/AdvancedFlightComputer/Features/AutoStage/AutoStageExecution.cs
+++ b/AdvancedFlightComputer/Features/AutoStage/AutoStageExecution.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using AdvancedFlightComputer.Core;
 using Brutal.Logging;
 using Brutal.Numerics;
 using HarmonyLib;
@@ -61,6 +63,9 @@ static class Patch_AutoStageExecution
 
     static void Postfix(Vehicle __instance, FlightComputerBurnMode __state)
     {
+#if DEBUG
+        long perfStart = DebugConfig.Performance ? Stopwatch.GetTimestamp() : 0;
+#endif
         if (__instance != Program.ControlledVehicle) return;
 
         if (!AutoStage.Enabled)
@@ -106,7 +111,7 @@ static class Patch_AutoStageExecution
 
             if (hasNextEngineStage)
             {
-                if (Mod.DebugMode)
+                if (DebugConfig.AutoStage)
                 {
                     DefaultCategory.Log.Debug(
                         $"[AFC] Auto-staging: dV remaining = {fc.Burn.DeltaVToGoCci.Length():F1} m/s");
@@ -117,5 +122,10 @@ static class Patch_AutoStageExecution
                 _graceFrames = 3; // see class doc comment for timing analysis
             }
         }
+
+#if DEBUG
+        if (DebugConfig.Performance)
+            PerfTracker.Record("AutoStageExecution.Postfix", Stopwatch.GetTimestamp() - perfStart);
+#endif
     }
 }

--- a/AdvancedFlightComputer/Features/AutoStage/AutoStageState.cs
+++ b/AdvancedFlightComputer/Features/AutoStage/AutoStageState.cs
@@ -48,7 +48,7 @@ static class AutoStage
 
         dict["AfcAutoStage"] = typeof(AfcAutoStage);
 
-        if (Mod.DebugMode)
+        if (DebugConfig.AutoStage)
         {
             DefaultCategory.Log.Debug(
                 $"[AFC] Injected AfcAutoStage into _enumLookup ({dict.Count} entries total).");
@@ -81,7 +81,7 @@ static class AutoStage
         harmony.CreateClassProcessor(typeof(Patch_Vehicle_IsFlightComputerDisabled)).Patch();
         harmony.CreateClassProcessor(typeof(Patch_AutoStageExecution)).Patch();
 
-        if (Mod.DebugMode)
+        if (DebugConfig.AutoStage)
             DefaultCategory.Log.Debug("[AFC] AutoStage: all patches applied.");
     }
 }

--- a/AdvancedFlightComputer/Features/AutoStage/GaugeButtonPatches.cs
+++ b/AdvancedFlightComputer/Features/AutoStage/GaugeButtonPatches.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using AdvancedFlightComputer.Core;
 using Brutal.Logging;
 using HarmonyLib;
 using KSA;
@@ -21,7 +22,7 @@ static class Patch_Vehicle_ToggleEnum
 
         AutoStage.Enabled = !AutoStage.Enabled;
 
-        if (Mod.DebugMode)
+        if (DebugConfig.AutoStage)
         {
             DefaultCategory.Log.Debug($"[AFC] AutoStage.Enabled = {AutoStage.Enabled}");
         }

--- a/AdvancedFlightComputer/Features/HyperbolicTargets/DiagnosticPatches.cs
+++ b/AdvancedFlightComputer/Features/HyperbolicTargets/DiagnosticPatches.cs
@@ -14,7 +14,7 @@ static class Patch_DiagnosticLog
 {
     static void Postfix(bool __result)
     {
-        if (!__result || !Mod.DebugMode) return;
+        if (!__result || !DebugConfig.HyperbolicTargets) return;
 
         try
         {

--- a/AdvancedFlightComputer/Features/HyperbolicTargets/EncounterPatches.cs
+++ b/AdvancedFlightComputer/Features/HyperbolicTargets/EncounterPatches.cs
@@ -1,4 +1,5 @@
 using System;
+using AdvancedFlightComputer.Core;
 using Brutal.Logging;
 using Brutal.Numerics;
 using HarmonyLib;
@@ -56,7 +57,7 @@ static class Patch_TryFindIntercept
                 selectedEntry.TransferData.ClosestApproachDistance = patchedConicDist;
                 __result = true;
 
-                if (Mod.DebugMode)
+                if (DebugConfig.HyperbolicTargets)
                 {
                     DefaultCategory.Log.Debug(
                         $"[AFC] RefineBurnTask: hyperbolic target, " +

--- a/AdvancedFlightComputer/Features/HyperbolicTargets/HyperbolicTargets.cs
+++ b/AdvancedFlightComputer/Features/HyperbolicTargets/HyperbolicTargets.cs
@@ -1,3 +1,4 @@
+using AdvancedFlightComputer.Core;
 using Brutal.Logging;
 using HarmonyLib;
 using KSA;
@@ -45,7 +46,7 @@ static class HyperbolicTargets
         harmony.CreateClassProcessor(typeof(Patch_ClipPointGeneration)).Patch();
         harmony.CreateClassProcessor(typeof(Patch_DiagnosticLog)).Patch();
 
-        if (Mod.DebugMode)
+        if (DebugConfig.HyperbolicTargets)
             DefaultCategory.Log.Debug("[AFC] HyperbolicTargets: all patches applied.");
     }
 

--- a/AdvancedFlightComputer/Features/HyperbolicTargets/OrbitRenderingPatches.cs
+++ b/AdvancedFlightComputer/Features/HyperbolicTargets/OrbitRenderingPatches.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using AdvancedFlightComputer.Core;
 using Brutal.Logging;
 using Brutal.Numerics;
 using CommunityToolkit.HighPerformance.Buffers;
@@ -24,6 +26,9 @@ static class Patch_ClipPointGeneration
     static bool Prefix(PatchedConic? patch, Orbit o,
         ref MemoryOwner<OrbitPointCce> __result)
     {
+#if DEBUG
+        long perfStart = DebugConfig.Performance ? Stopwatch.GetTimestamp() : 0;
+#endif
         if (o.IsBound()) return true;
 
         // Only intervene when the original would fall back to -Pi..+Pi.
@@ -69,6 +74,10 @@ static class Patch_ClipPointGeneration
             }
 
             __result = points;
+#if DEBUG
+            if (DebugConfig.Performance)
+                PerfTracker.Record("ClipPointGeneration.Prefix", Stopwatch.GetTimestamp() - perfStart);
+#endif
             return false;
         }
         catch (Exception ex)

--- a/AdvancedFlightComputer/Features/StageInfo/BurnDurationPatch.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/BurnDurationPatch.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using AdvancedFlightComputer.Core;
 using HarmonyLib;
 using KSA;
 
@@ -24,6 +26,9 @@ static class Patch_CorrectedBurnDuration
 {
     static void Postfix(Vehicle __instance)
     {
+#if DEBUG
+        long perfStart = DebugConfig.Performance ? Stopwatch.GetTimestamp() : 0;
+#endif
         if (__instance != Program.ControlledVehicle) return;
 
         FlightComputer fc = __instance.FlightComputer;
@@ -34,5 +39,10 @@ static class Patch_CorrectedBurnDuration
 
         fc.Burn.BurnDuration = corrected.Value;
         fc.Burn.IgnitionTime = fc.Burn.ImpulsiveInstant - 0.5 * (double)fc.Burn.BurnDuration;
+
+#if DEBUG
+        if (DebugConfig.Performance)
+            PerfTracker.Record("CorrectedBurnDuration.Postfix", Stopwatch.GetTimestamp() - perfStart);
+#endif
     }
 }

--- a/AdvancedFlightComputer/Features/StageInfo/StageAnalyzer.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageAnalyzer.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using AdvancedFlightComputer.Core;
 using Brutal.Logging;
 using CommunityToolkit.HighPerformance.Buffers;
 using KSA;
@@ -100,6 +102,9 @@ public static class StageAnalyzer
     /// </summary>
     public static VehicleBurnAnalysis Analyze(Vehicle vehicle, bool log = false)
     {
+#if DEBUG
+        long perfStart = DebugConfig.Performance ? Stopwatch.GetTimestamp() : 0;
+#endif
         _pooledStages.Clear();
         _pooledJettisonedPartIds.Clear();
         _pooledFuelClaimedTankIds.Clear();
@@ -266,6 +271,10 @@ public static class StageAnalyzer
                 $"total dV={result.TotalDeltaV:F1} m/s, total burn={result.TotalBurnTime:F1} s");
         }
 
+#if DEBUG
+        if (DebugConfig.Performance)
+            PerfTracker.Record("StageAnalyzer.Analyze", Stopwatch.GetTimestamp() - perfStart);
+#endif
         return result;
     }
 

--- a/AdvancedFlightComputer/Features/StageInfo/StageAnalyzerDebug.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageAnalyzerDebug.cs
@@ -1,3 +1,4 @@
+using AdvancedFlightComputer.Core;
 using Brutal.Logging;
 using HarmonyLib;
 using KSA;
@@ -29,7 +30,7 @@ static class StageAnalyzerDebug
     {
         static void Postfix(Vehicle vehicle)
         {
-            if (!Mod.DebugMode) return;
+            if (!DebugConfig.StageInfo) return;
             if (vehicle != Program.ControlledVehicle) return;
 
             DefaultCategory.Log.Info("[AFC] Staging event detected, running StageAnalyzer...");
@@ -46,7 +47,7 @@ static class StageAnalyzerDebug
     {
         static void Postfix(Vehicle __instance)
         {
-            if (!Mod.DebugMode) return;
+            if (!DebugConfig.StageInfo) return;
             if (__instance != Program.ControlledVehicle) return;
 
             string vehicleId = __instance.Id;

--- a/AdvancedFlightComputer/Features/StageInfo/StageInfoPanel.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageInfoPanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using AdvancedFlightComputer.Core;
@@ -89,7 +90,7 @@ static class StageInfoPanel
         harmony.CreateClassProcessor(typeof(StageAnalyzerDebug.Patch_AnalyzeAfterStaging)).Patch();
         harmony.CreateClassProcessor(typeof(StageAnalyzerDebug.Patch_InitialAnalysis)).Patch();
 
-        if (Mod.DebugMode)
+        if (DebugConfig.StageInfo)
             DefaultCategory.Log.Debug("[AFC] StageInfo: all patches applied.");
 
         return true;
@@ -154,6 +155,9 @@ static class StageInfoPanel
     /// </summary>
     static bool DrawContentPrefix(object __instance, Viewport viewport)
     {
+#if DEBUG
+        long perfStart = DebugConfig.Performance ? Stopwatch.GetTimestamp() : 0;
+#endif
         Vehicle? vehicle = Program.ControlledVehicle;
         if (vehicle == null)
             return false;
@@ -243,6 +247,10 @@ static class StageInfoPanel
 
         DrawTotalFooter();
 
+#if DEBUG
+        if (DebugConfig.Performance)
+            PerfTracker.Record("DrawContentPrefix", Stopwatch.GetTimestamp() - perfStart);
+#endif
         return false;
     }
 

--- a/AdvancedFlightComputer/Mod.cs
+++ b/AdvancedFlightComputer/Mod.cs
@@ -16,11 +16,7 @@ public class Mod
 
     private const string TestedGameVersion = "v2026.2.35.3667";
 
-#if DEBUG
-    public static bool DebugMode = true;
-#else
-    public static bool DebugMode = false;
-#endif
+    public static bool DebugMode => DebugConfig.Any;
 
     /// <summary>
     /// Runs during Mod.PrepareSystems(), BEFORE the game processes Gauges.xml.
@@ -30,7 +26,7 @@ public class Mod
     [StarMapImmediateLoad]
     public void OnImmediateLoad(KSA.Mod mod)
     {
-        if (DebugMode)
+        if (DebugConfig.AutoStage)
             DefaultCategory.Log.Debug("[AFC] ImmediateLoad: ensuring enum injection...");
 
         AutoStage.InjectEnumLookup();
@@ -77,6 +73,9 @@ public class Mod
         StageInfoPanel.Reset();
         StageAnalyzer.ResetPools();
         LogHelper.Reset();
+#if DEBUG
+        PerfTracker.Reset();
+#endif
         DefaultCategory.Log.Info("[AFC] Unloaded.");
     }
 }


### PR DESCRIPTION
## Summary
- Replace single `Mod.DebugMode` bool with per-feature flags in `DebugConfig` (`HyperbolicTargets`, `AutoStage`, `StageInfo`, `Performance`) to debug individual features without log spam from the others
- Add `PerfTracker` that accumulates Stopwatch timings for 5 hot-path methods and reports avg/min/max every 5 seconds (`#if DEBUG` only)
- Deploy mod to game folder for both Debug and Release builds (was Debug-only before)