### PR TITLE
Fix worker-thread ignition timing for multi-stage burns

### DIFF
--- a/AdvancedFlightComputer/Core/GameReflection.cs
+++ b/AdvancedFlightComputer/Core/GameReflection.cs
@@ -50,6 +50,9 @@ static class GameReflection
     public static readonly MethodInfo? StagingWindow_DrawComponentOpen =
         StagingWindowType?.GetMethod("DrawComponent", BindingFlags.NonPublic | BindingFlags.Instance);
 
+    public static readonly MethodInfo? FlightComputer_UpdateBurnTarget =
+        AccessTools.Method(typeof(FlightComputer), "UpdateBurnTarget");
+
     #endregion
 
     #region Validation

--- a/AdvancedFlightComputer/Features/StageInfo/BurnDurationPatch.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/BurnDurationPatch.cs
@@ -6,20 +6,47 @@ using KSA;
 namespace AdvancedFlightComputer.Features.StageInfo;
 
 /// <summary>
-/// Overrides BurnDuration and IgnitionTime with multi-stage values after the
-/// background job's FlightComputer copy is applied on the main thread.
+/// Thread-safe state transfer for the corrected multi-stage burn duration.
+/// Written on the main thread by Patch_CorrectedBurnDuration, read on the
+/// worker thread by Patch_WorkerIgnitionTiming.
 ///
-/// The game's UpdateBurnTarget (worker thread) computes a single-stage
-/// BurnDuration using only the currently active engines. This postfix
-/// replaces it with the multi-stage burn time from our StageAnalyzer,
-/// which accounts for all future stages.
+/// Uses volatile fields for cross-thread visibility. Float and reference
+/// reads/writes are atomic on x64. One-frame staleness is acceptable
+/// because the correction value changes slowly (dV consumed per frame is
+/// tiny relative to total burn dV).
+/// </summary>
+static class CorrectedBurnState
+{
+    /// <summary>
+    /// The BurnTarget reference from the controlled vehicle, used for
+    /// identification on the worker thread via reference equality.
+    /// The FC copy constructor does Burn = existing.Burn (shared reference),
+    /// so the worker thread's FC has the same BurnTarget object.
+    /// </summary>
+    public static volatile BurnTarget? TrackedBurn;
+
+    /// <summary>
+    /// The multi-stage burn duration in seconds, computed by
+    /// StageAnalyzer.AnalyzeBurn. Only valid when TrackedBurn is non-null.
+    /// </summary>
+    public static volatile float CorrectedDuration;
+
+    public static void Clear()
+    {
+        TrackedBurn = null;
+        CorrectedDuration = 0f;
+    }
+}
+
+/// <summary>
+/// Drives per-frame stage analysis and corrects BurnDuration/IgnitionTime
+/// with multi-stage values on the main thread.
 ///
-/// This corrects the BURN TIME and START BURN IN gauge rollers, which
-/// read from FlightComputer.Burn on the main thread during the render pass.
-///
-/// The worker thread's ignition decision uses its own freshly-computed
-/// single-stage value (slightly off for multi-stage burns). This is
-/// acceptable because auto-staging handles burn continuation.
+/// Runs as a Postfix on Vehicle.UpdateFromTaskResults, which fires every
+/// frame for every vehicle. Calls StageAnalysisCache.Update() to run the
+/// analysis (conditionally - skipped when no burn and panel not visible),
+/// then applies the corrected burn duration to fc.Burn and publishes
+/// CorrectedBurnState for the worker thread.
 /// </summary>
 [HarmonyPatch(typeof(Vehicle), "UpdateFromTaskResults")]
 static class Patch_CorrectedBurnDuration
@@ -31,18 +58,70 @@ static class Patch_CorrectedBurnDuration
 #endif
         if (__instance != Program.ControlledVehicle) return;
 
-        FlightComputer fc = __instance.FlightComputer;
-        if (fc.Burn == null) return;
+        StageAnalysisCache.Update(__instance);
 
-        float? corrected = StageInfoPanel.GetCorrectedBurnDuration();
-        if (corrected == null || corrected.Value <= 0f) return;
+        FlightComputer fc = __instance.FlightComputer;
+        if (fc.Burn == null)
+        {
+            CorrectedBurnState.Clear();
+            return;
+        }
+
+        float? corrected = StageAnalysisCache.GetCorrectedBurnDuration();
+        if (corrected == null || corrected.Value <= 0f)
+        {
+            CorrectedBurnState.Clear();
+            return;
+        }
 
         fc.Burn.BurnDuration = corrected.Value;
         fc.Burn.IgnitionTime = fc.Burn.ImpulsiveInstant - 0.5 * (double)fc.Burn.BurnDuration;
+
+        CorrectedBurnState.CorrectedDuration = corrected.Value;
+        CorrectedBurnState.TrackedBurn = fc.Burn;
 
 #if DEBUG
         if (DebugConfig.Performance)
             PerfTracker.Record("CorrectedBurnDuration.Postfix", Stopwatch.GetTimestamp() - perfStart);
 #endif
+    }
+}
+
+/// <summary>
+/// Postfix on FlightComputer.UpdateBurnTarget (worker thread) that overrides
+/// single-stage BurnDuration and IgnitionTime with multi-stage values.
+///
+/// UpdateBurnTarget computes BurnDuration from single-stage Tsiolkovsky, then
+/// derives IgnitionTime = ImpulsiveInstant - 0.5 * BurnDuration. This postfix
+/// runs immediately after, replacing both with the multi-stage values from
+/// CorrectedBurnState before ComputeControl uses IgnitionTime for the
+/// ignition decision.
+///
+/// Only applies in Auto burn mode because Manual mode does not use IgnitionTime
+/// for ignition decisions, and the game's throttle-adjusted BurnDuration should
+/// be preserved for display.
+///
+/// Identifies the controlled vehicle's FC via BurnTarget reference equality:
+/// the FC copy constructor does Burn = existing.Burn (shared reference), so
+/// comparing against CorrectedBurnState.TrackedBurn correctly identifies
+/// only the controlled vehicle's FlightComputer.
+/// </summary>
+static class Patch_WorkerIgnitionTiming
+{
+    public static void Postfix(FlightComputer __instance)
+    {
+        if (__instance.BurnMode != FlightComputerBurnMode.Auto) return;
+
+        BurnTarget? burn = __instance.Burn;
+        if (burn == null) return;
+
+        BurnTarget? tracked = CorrectedBurnState.TrackedBurn;
+        if (tracked == null || !ReferenceEquals(burn, tracked)) return;
+
+        float duration = CorrectedBurnState.CorrectedDuration;
+        if (duration <= 0f) return;
+
+        burn.BurnDuration = duration;
+        burn.IgnitionTime = burn.ImpulsiveInstant - 0.5 * (double)duration;
     }
 }

--- a/AdvancedFlightComputer/Features/StageInfo/StageAnalysisCache.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageAnalysisCache.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using AdvancedFlightComputer.Core;
+using KSA;
+
+namespace AdvancedFlightComputer.Features.StageInfo;
+
+/// <summary>
+/// Centralized cache for stage analysis results. Decoupled from UI rendering
+/// so analysis is available regardless of whether the staging panel is visible.
+///
+/// Called from Patch_CorrectedBurnDuration.Postfix (on UpdateFromTaskResults)
+/// which fires every frame for the controlled vehicle. Results are consumed by:
+/// - StageInfoPanel (UI rendering when panel is visible)
+/// - Patch_CorrectedBurnDuration (main-thread burn duration/ignition correction)
+/// - CorrectedBurnState -> Patch_WorkerIgnitionTiming (worker-thread ignition)
+///
+/// Analysis is skipped when neither a burn is planned nor the staging panel is
+/// visible, avoiding unnecessary computation.
+/// </summary>
+static class StageAnalysisCache
+{
+    private static VehicleBurnAnalysis? _cachedAnalysis;
+    private static readonly Dictionary<int, StageBurnInfo> _stageInfoLookup = new();
+    private static BurnAnalysis? _cachedBurnAnalysis;
+    private static readonly Dictionary<int, BurnStageAllocation> _burnAllocationLookup = new();
+
+    /// <summary>
+    /// Set by DrawContentPrefix each frame the staging panel is rendered.
+    /// Read and reset by Update() to determine if analysis is needed for
+    /// UI display. One-frame lag when panel first opens is invisible.
+    /// </summary>
+    private static bool _panelNeedsData;
+
+    #region Public API
+
+    /// <summary>
+    /// Signals that the staging panel needs analysis data next frame.
+    /// Called from StageInfoPanel.DrawContentPrefix every rendered frame.
+    /// </summary>
+    public static void MarkPanelActive() => _panelNeedsData = true;
+
+    /// <summary>
+    /// Runs stage analysis if needed (burn planned or panel visible).
+    /// Called once per frame from Patch_CorrectedBurnDuration.Postfix.
+    /// </summary>
+    public static void Update(Vehicle vehicle)
+    {
+#if DEBUG
+        long perfStart = DebugConfig.Performance ? Stopwatch.GetTimestamp() : 0;
+#endif
+        bool hasBurn = vehicle.FlightComputer.Burn != null;
+        bool panelActive = _panelNeedsData;
+        _panelNeedsData = false;
+
+        if (!hasBurn && !panelActive)
+        {
+            Clear();
+            return;
+        }
+
+        _cachedAnalysis = StageAnalyzer.Analyze(vehicle);
+
+        _stageInfoLookup.Clear();
+        foreach (var stage in _cachedAnalysis.Value.Stages)
+            _stageInfoLookup[stage.StageNumber] = stage;
+
+        if (hasBurn)
+            UpdateBurnAnalysis(vehicle.FlightComputer.Burn!);
+        else
+            ClearBurnAnalysis();
+
+#if DEBUG
+        if (DebugConfig.Performance)
+            PerfTracker.Record("StageAnalysisCache.Update", Stopwatch.GetTimestamp() - perfStart);
+#endif
+    }
+
+    public static VehicleBurnAnalysis? Analysis => _cachedAnalysis;
+    public static BurnAnalysis? BurnAnalysis => _cachedBurnAnalysis;
+
+    public static bool TryGetStageInfo(int stageNumber, out StageBurnInfo info)
+        => _stageInfoLookup.TryGetValue(stageNumber, out info);
+
+    public static bool TryGetBurnAllocation(int stageNumber, out BurnStageAllocation alloc)
+        => _burnAllocationLookup.TryGetValue(stageNumber, out alloc);
+
+    /// <summary>
+    /// Returns the cached multi-stage burn time, or null if no burn analysis
+    /// is available. Used by Patch_CorrectedBurnDuration and CorrectedBurnState.
+    /// </summary>
+    public static float? GetCorrectedBurnDuration()
+        => _cachedBurnAnalysis?.TotalBurnTime;
+
+    public static void Reset()
+    {
+        Clear();
+        _panelNeedsData = false;
+    }
+
+    #endregion
+
+    #region Private Helpers
+
+    private static void UpdateBurnAnalysis(BurnTarget burn)
+    {
+        if (_cachedAnalysis == null)
+        {
+            ClearBurnAnalysis();
+            return;
+        }
+
+        float requiredDv = burn.DeltaVToGoCci.Length();
+        if (requiredDv <= 0f)
+        {
+            ClearBurnAnalysis();
+            return;
+        }
+
+        _cachedBurnAnalysis = StageAnalyzer.AnalyzeBurn(_cachedAnalysis.Value, requiredDv);
+
+        _burnAllocationLookup.Clear();
+        foreach (var alloc in _cachedBurnAnalysis.Value.StageAllocations)
+            _burnAllocationLookup[alloc.StageNumber] = alloc;
+    }
+
+    private static void ClearBurnAnalysis()
+    {
+        _cachedBurnAnalysis = null;
+        _burnAllocationLookup.Clear();
+    }
+
+    private static void Clear()
+    {
+        _cachedAnalysis = null;
+        _stageInfoLookup.Clear();
+        ClearBurnAnalysis();
+    }
+
+    #endregion
+}

--- a/AdvancedFlightComputer/Features/StageInfo/StageInfoPanel.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageInfoPanel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -16,22 +15,12 @@ namespace AdvancedFlightComputer.Features.StageInfo;
 /// Extends the Staging window with per-stage Delta V, TWR, burn time, ISP,
 /// and a fuel progress bar. Also shows total Delta V in a footer.
 ///
+/// Pure rendering code - reads all analysis data from StageAnalysisCache.
 /// Since StagingWindow is a private nested class of Staging, we use manual
-/// Harmony patching to replace its DrawContent method. The Prefix re-implements
-/// the original rendering and adds our data inline (progress bar on the stage
-/// header line, info text when expanded).
-///
-/// Analysis runs every frame using pooled collections in StageAnalyzer to
-/// avoid GC pressure from per-frame allocations.
+/// Harmony patching to replace its DrawContent method.
 /// </summary>
 static class StageInfoPanel
 {
-    private static VehicleBurnAnalysis? _cachedAnalysis;
-    private static readonly Dictionary<int, StageBurnInfo> _stageInfoLookup = new();
-    private static BurnAnalysis? _cachedBurnAnalysis;
-    private static readonly Dictionary<int, BurnStageAllocation> _burnAllocationLookup = new();
-    private static string? _lastVehicleId;
-
     private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
 
     private static readonly ImColor8 ColorInsufficient = new ImColor8(255, 60, 60, 255);
@@ -71,6 +60,7 @@ static class StageInfoPanel
     /// Applies all StageInfo Harmony patches. Called from Mod.cs after
     /// GameReflection.ValidateStageInfo() passes. Includes:
     /// - StagingWindow.DrawContent replacement (manual patch)
+    /// - Worker-thread ignition timing fix (manual patch)
     /// - Corrected burn duration postfix
     /// - StageAnalyzerDebug patches (debug-only analysis logging)
     /// </summary>
@@ -86,6 +76,18 @@ static class StageInfoPanel
         harmony.Patch(GameReflection.StagingWindow_DrawContent!,
             prefix: new HarmonyMethod(typeof(StageInfoPanel), nameof(DrawContentPrefix)));
 
+        if (GameReflection.FlightComputer_UpdateBurnTarget != null)
+        {
+            harmony.Patch(GameReflection.FlightComputer_UpdateBurnTarget,
+                postfix: new HarmonyMethod(typeof(Patch_WorkerIgnitionTiming),
+                    nameof(Patch_WorkerIgnitionTiming.Postfix)));
+        }
+        else
+        {
+            DefaultCategory.Log.Warning(
+                "[AFC] FlightComputer.UpdateBurnTarget not found - worker ignition timing fix disabled.");
+        }
+
         harmony.CreateClassProcessor(typeof(Patch_CorrectedBurnDuration)).Patch();
         harmony.CreateClassProcessor(typeof(StageAnalyzerDebug.Patch_AnalyzeAfterStaging)).Patch();
         harmony.CreateClassProcessor(typeof(StageAnalyzerDebug.Patch_InitialAnalysis)).Patch();
@@ -96,62 +98,12 @@ static class StageInfoPanel
         return true;
     }
 
-    public static void Reset()
-    {
-        _cachedAnalysis = null;
-        _stageInfoLookup.Clear();
-        _cachedBurnAnalysis = null;
-        _burnAllocationLookup.Clear();
-        _lastVehicleId = null;
-    }
-
-    #region Cache Management
-
-    private static void UpdateCache(Vehicle vehicle)
-    {
-        _lastVehicleId = vehicle.Id;
-        _cachedAnalysis = StageAnalyzer.Analyze(vehicle);
-
-        _stageInfoLookup.Clear();
-        foreach (var stage in _cachedAnalysis.Value.Stages)
-            _stageInfoLookup[stage.StageNumber] = stage;
-
-        UpdateBurnAnalysisCache(vehicle);
-    }
-
-    private static void UpdateBurnAnalysisCache(Vehicle vehicle)
-    {
-        BurnTarget? burn = vehicle.FlightComputer.Burn;
-        if (burn == null || _cachedAnalysis == null)
-        {
-            _cachedBurnAnalysis = null;
-            _burnAllocationLookup.Clear();
-            return;
-        }
-
-        float requiredDv = burn.DeltaVToGoCci.Length();
-        if (requiredDv <= 0f)
-        {
-            _cachedBurnAnalysis = null;
-            _burnAllocationLookup.Clear();
-            return;
-        }
-
-        _cachedBurnAnalysis = StageAnalyzer.AnalyzeBurn(_cachedAnalysis.Value, requiredDv);
-
-        _burnAllocationLookup.Clear();
-        foreach (var alloc in _cachedBurnAnalysis.Value.StageAllocations)
-            _burnAllocationLookup[alloc.StageNumber] = alloc;
-    }
-
-    #endregion
-
     #region DrawContent Replacement
 
     /// <summary>
     /// Replaces StagingWindow.DrawContent. Re-implements the original stage tree
     /// rendering and adds per-stage info (progress bar, Delta V, TWR, burn time,
-    /// ISP) plus a total footer.
+    /// ISP) plus a total footer. Reads all data from StageAnalysisCache.
     /// </summary>
     static bool DrawContentPrefix(object __instance, Viewport viewport)
     {
@@ -162,7 +114,7 @@ static class StageInfoPanel
         if (vehicle == null)
             return false;
 
-        UpdateCache(vehicle);
+        StageAnalysisCache.MarkPanelActive();
 
         float footerHeight = ImGui.GetTextLineHeightWithSpacing() + 4f;
         float tableHeight = ImGui.GetContentRegionAvail().Y - footerHeight;
@@ -269,7 +221,7 @@ static class StageInfoPanel
 
     private static void DrawStageProgressBar(int stageNumber)
     {
-        if (!_stageInfoLookup.TryGetValue(stageNumber, out var info)) return;
+        if (!StageAnalysisCache.TryGetStageInfo(stageNumber, out var info)) return;
         if (info.EngineCount == 0) return;
 
         ImGui.SameLine();
@@ -294,7 +246,7 @@ static class StageInfoPanel
 
     private static void DrawStageInfoLine(int stageNumber)
     {
-        if (!_stageInfoLookup.TryGetValue(stageNumber, out var info)) return;
+        if (!StageAnalysisCache.TryGetStageInfo(stageNumber, out var info)) return;
         if (info.EngineCount == 0) return;
 
         ImGui.TableNextRow();
@@ -311,10 +263,8 @@ static class StageInfoPanel
         string burnTimeText = string.Format(Inv, "Burn Time: {0}", FormatBurnTime(info.BurnTime));
         string ispText = string.Format(Inv, "ISP: {0:F0}s", info.Isp);
 
-        // When a burn is planned and this stage is involved, color the Delta V
-        // text and show how much dV the burn needs from this stage.
         BurnStageAllocation? alloc = null;
-        if (_burnAllocationLookup.TryGetValue(stageNumber, out var a))
+        if (StageAnalysisCache.TryGetBurnAllocation(stageNumber, out var a))
             alloc = a;
 
         if (alloc != null)
@@ -369,17 +319,19 @@ static class StageInfoPanel
 
     private static void DrawTotalFooter()
     {
-        if (_cachedAnalysis == null) return;
-        var analysis = _cachedAnalysis.Value;
-        if (analysis.Stages.Count == 0) return;
+        var analysis = StageAnalysisCache.Analysis;
+        if (analysis == null) return;
+        var stages = analysis.Value;
+        if (stages.Stages.Count == 0) return;
 
         ImGui.Separator();
 
-        if (_cachedBurnAnalysis != null)
+        var burnAnalysis = StageAnalysisCache.BurnAnalysis;
+        if (burnAnalysis != null)
         {
-            var burn = _cachedBurnAnalysis.Value;
+            var burn = burnAnalysis.Value;
             string totalText = string.Format(Inv,
-                "Total Delta V: {0:N0} m/s", analysis.TotalDeltaV);
+                "Total Delta V: {0:N0} m/s", stages.TotalDeltaV);
             ImGui.Text(totalText);
             ImGui.SameLine();
             ImGui.Text("|");
@@ -405,23 +357,9 @@ static class StageInfoPanel
         {
             string totalText = string.Format(Inv,
                 "Total Delta V: {0:N0} m/s  Burn Time: {1}",
-                analysis.TotalDeltaV, FormatBurnTime(analysis.TotalBurnTime));
+                stages.TotalDeltaV, FormatBurnTime(stages.TotalBurnTime));
             ImGui.Text(totalText);
         }
-    }
-
-    #endregion
-
-    #region Corrected Burn Duration
-
-    /// <summary>
-    /// Returns the cached multi-stage burn time, or null if no burn analysis
-    /// is available. Used by Patch_CorrectedBurnDuration to override the
-    /// single-stage BurnDuration computed by the game's UpdateBurnTarget.
-    /// </summary>
-    internal static float? GetCorrectedBurnDuration()
-    {
-        return _cachedBurnAnalysis?.TotalBurnTime;
     }
 
     #endregion

--- a/AdvancedFlightComputer/Mod.cs
+++ b/AdvancedFlightComputer/Mod.cs
@@ -70,7 +70,8 @@ public class Mod
         AutoStage.Enabled = false;
         Patch_AutoStageExecution.Reset();
         StageAnalyzerDebug.Reset();
-        StageInfoPanel.Reset();
+        StageAnalysisCache.Reset();
+        CorrectedBurnState.Clear();
         StageAnalyzer.ResetPools();
         LogHelper.Reset();
 #if DEBUG


### PR DESCRIPTION
## Summary

- Fix incorrect ignition timing on the worker thread that caused multi-stage burns to start too late
- Decouple stage analysis from the staging panel UI so burn correction works even when the panel is closed
- Extract `StageAnalysisCache` from `StageInfoPanel`, making the panel pure rendering code

## Problem

The game's `FlightComputer.UpdateBurnTarget` (worker thread) computes `IgnitionTime = ImpulsiveInstant - 0.5 * BurnDuration` using only the current stage's engines. For a 3-stage burn with 180s total duration, it would compute 60s (current stage only), causing ignition 60 seconds too late.

The existing main-thread correction fixed gauge display but not the actual ignition decision, which happens on the worker thread.

## Solution

- `Patch_WorkerIgnitionTiming`: Harmony postfix on `UpdateBurnTarget` that overrides single-stage values with multi-stage values via `CorrectedBurnState` (volatile cross-thread state, identified by BurnTarget reference equality)
- `StageAnalysisCache`: Extracted from `StageInfoPanel`, runs from `UpdateFromTaskResults` postfix (always fires). Skips analysis when no burn planned and panel not visible.

Closes #10 