### PR TITLE
Add atmospheric thrust calculations to Stage Info panel

### DIFF
--- a/AdvancedFlightComputer/Features/StageInfo/StageAnalysisCache.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageAnalysisCache.cs
@@ -17,13 +17,42 @@ namespace AdvancedFlightComputer.Features.StageInfo;
 ///
 /// Analysis is skipped when neither a burn is planned nor the staging panel is
 /// visible, avoiding unnecessary computation.
+///
+/// Supports dual analysis for VacAsl display mode. StageAnalyzer uses pooled
+/// collections internally, so results must be copied into cache-owned lists
+/// before the second Analyze() call overwrites the pool.
 /// </summary>
 static class StageAnalysisCache
 {
+    #region Primary Analysis
+
     private static VehicleBurnAnalysis? _cachedAnalysis;
+    private static readonly List<StageBurnInfo> _cachedPrimaryStages = new();
     private static readonly Dictionary<int, StageBurnInfo> _stageInfoLookup = new();
     private static BurnAnalysis? _cachedBurnAnalysis;
+    private static readonly List<BurnStageAllocation> _cachedPrimaryAllocations = new();
     private static readonly Dictionary<int, BurnStageAllocation> _burnAllocationLookup = new();
+
+    #endregion
+
+    #region Secondary Analysis (VacAsl mode)
+
+    private static VehicleBurnAnalysis? _cachedSecondaryAnalysis;
+    private static readonly List<StageBurnInfo> _cachedSecondaryStages = new();
+    private static readonly Dictionary<int, StageBurnInfo> _secondaryStageInfoLookup = new();
+    private static BurnAnalysis? _cachedSecondaryBurnAnalysis;
+    private static readonly List<BurnStageAllocation> _cachedSecondaryAllocations = new();
+    private static readonly Dictionary<int, BurnStageAllocation> _secondaryBurnAllocationLookup = new();
+
+    #endregion
+
+    #region Display State
+
+    public static string PrimaryLabel { get; private set; } = "";
+    public static string? SecondaryLabel { get; private set; }
+    public static bool IsPrimaryCurrentCondition { get; private set; } = true;
+
+    #endregion
 
     /// <summary>
     /// Set by DrawContentPrefix each frame the staging panel is rendered.
@@ -59,16 +88,32 @@ static class StageAnalysisCache
             return;
         }
 
-        _cachedAnalysis = StageAnalyzer.Analyze(vehicle);
+        var env = StageInfoSettings.ResolveEnvironment(vehicle);
+        PrimaryLabel = env.PrimaryLabel;
+        SecondaryLabel = env.SecondaryLabel;
+        IsPrimaryCurrentCondition = env.IsPrimaryCurrentCondition;
 
-        _stageInfoLookup.Clear();
-        foreach (var stage in _cachedAnalysis.Value.Stages)
-            _stageInfoLookup[stage.StageNumber] = stage;
+        RunPrimaryAnalysis(vehicle, env);
 
-        if (hasBurn)
-            UpdateBurnAnalysis(vehicle.FlightComputer.Burn!);
+        if (env.SecondaryPressure.HasValue)
+            RunSecondaryAnalysis(vehicle, env);
         else
+            ClearSecondary();
+
+        float requiredDv = hasBurn ? vehicle.FlightComputer.Burn!.DeltaVToGoCci.Length() : 0f;
+        if (hasBurn && requiredDv > 0f)
+        {
+            UpdateBurnAnalysis(requiredDv);
+            if (_cachedSecondaryAnalysis != null)
+                UpdateSecondaryBurnAnalysis(requiredDv);
+            else
+                ClearSecondaryBurnAnalysis();
+        }
+        else
+        {
             ClearBurnAnalysis();
+            ClearSecondaryBurnAnalysis();
+        }
 
 #if DEBUG
         if (DebugConfig.Performance)
@@ -78,12 +123,20 @@ static class StageAnalysisCache
 
     public static VehicleBurnAnalysis? Analysis => _cachedAnalysis;
     public static BurnAnalysis? BurnAnalysis => _cachedBurnAnalysis;
+    public static VehicleBurnAnalysis? SecondaryAnalysis => _cachedSecondaryAnalysis;
+    public static BurnAnalysis? SecondaryBurnAnalysis => _cachedSecondaryBurnAnalysis;
 
     public static bool TryGetStageInfo(int stageNumber, out StageBurnInfo info)
         => _stageInfoLookup.TryGetValue(stageNumber, out info);
 
     public static bool TryGetBurnAllocation(int stageNumber, out BurnStageAllocation alloc)
         => _burnAllocationLookup.TryGetValue(stageNumber, out alloc);
+
+    public static bool TryGetSecondaryStageInfo(int stageNumber, out StageBurnInfo info)
+        => _secondaryStageInfoLookup.TryGetValue(stageNumber, out info);
+
+    public static bool TryGetSecondaryBurnAllocation(int stageNumber, out BurnStageAllocation alloc)
+        => _secondaryBurnAllocationLookup.TryGetValue(stageNumber, out alloc);
 
     /// <summary>
     /// Returns the cached multi-stage burn time, or null if no burn analysis
@@ -95,14 +148,60 @@ static class StageAnalysisCache
     public static void Reset()
     {
         Clear();
+        ClearSecondary();
         _panelNeedsData = false;
+        PrimaryLabel = "";
+        SecondaryLabel = null;
+        IsPrimaryCurrentCondition = true;
     }
 
     #endregion
 
     #region Private Helpers
 
-    private static void UpdateBurnAnalysis(BurnTarget burn)
+    private static void RunPrimaryAnalysis(Vehicle vehicle, AnalysisEnvironment env)
+    {
+        var result = StageAnalyzer.Analyze(vehicle,
+            ambientPressure: env.PrimaryPressure,
+            surfaceGravityOverride: env.PrimarySurfaceGravity);
+
+        _cachedPrimaryStages.Clear();
+        _cachedPrimaryStages.AddRange(result.Stages);
+
+        _cachedAnalysis = new VehicleBurnAnalysis
+        {
+            Stages = _cachedPrimaryStages,
+            TotalDeltaV = result.TotalDeltaV,
+            TotalBurnTime = result.TotalBurnTime
+        };
+
+        _stageInfoLookup.Clear();
+        foreach (var stage in _cachedPrimaryStages)
+            _stageInfoLookup[stage.StageNumber] = stage;
+    }
+
+    private static void RunSecondaryAnalysis(Vehicle vehicle, AnalysisEnvironment env)
+    {
+        var result = StageAnalyzer.Analyze(vehicle,
+            ambientPressure: env.SecondaryPressure!.Value,
+            surfaceGravityOverride: env.SecondarySurfaceGravity);
+
+        _cachedSecondaryStages.Clear();
+        _cachedSecondaryStages.AddRange(result.Stages);
+
+        _cachedSecondaryAnalysis = new VehicleBurnAnalysis
+        {
+            Stages = _cachedSecondaryStages,
+            TotalDeltaV = result.TotalDeltaV,
+            TotalBurnTime = result.TotalBurnTime
+        };
+
+        _secondaryStageInfoLookup.Clear();
+        foreach (var stage in _cachedSecondaryStages)
+            _secondaryStageInfoLookup[stage.StageNumber] = stage;
+    }
+
+    private static void UpdateBurnAnalysis(float requiredDv)
     {
         if (_cachedAnalysis == null)
         {
@@ -110,18 +209,50 @@ static class StageAnalysisCache
             return;
         }
 
-        float requiredDv = burn.DeltaVToGoCci.Length();
-        if (requiredDv <= 0f)
+        var result = StageAnalyzer.AnalyzeBurn(_cachedAnalysis.Value, requiredDv);
+
+        _cachedPrimaryAllocations.Clear();
+        _cachedPrimaryAllocations.AddRange(result.StageAllocations);
+
+        _cachedBurnAnalysis = new BurnAnalysis
         {
-            ClearBurnAnalysis();
+            RequiredDv = result.RequiredDv,
+            AvailableDv = result.AvailableDv,
+            TotalBurnTime = result.TotalBurnTime,
+            IsSufficient = result.IsSufficient,
+            StageAllocations = _cachedPrimaryAllocations
+        };
+
+        _burnAllocationLookup.Clear();
+        foreach (var alloc in _cachedPrimaryAllocations)
+            _burnAllocationLookup[alloc.StageNumber] = alloc;
+    }
+
+    private static void UpdateSecondaryBurnAnalysis(float requiredDv)
+    {
+        if (_cachedSecondaryAnalysis == null)
+        {
+            ClearSecondaryBurnAnalysis();
             return;
         }
 
-        _cachedBurnAnalysis = StageAnalyzer.AnalyzeBurn(_cachedAnalysis.Value, requiredDv);
+        var result = StageAnalyzer.AnalyzeBurn(_cachedSecondaryAnalysis.Value, requiredDv);
 
-        _burnAllocationLookup.Clear();
-        foreach (var alloc in _cachedBurnAnalysis.Value.StageAllocations)
-            _burnAllocationLookup[alloc.StageNumber] = alloc;
+        _cachedSecondaryAllocations.Clear();
+        _cachedSecondaryAllocations.AddRange(result.StageAllocations);
+
+        _cachedSecondaryBurnAnalysis = new BurnAnalysis
+        {
+            RequiredDv = result.RequiredDv,
+            AvailableDv = result.AvailableDv,
+            TotalBurnTime = result.TotalBurnTime,
+            IsSufficient = result.IsSufficient,
+            StageAllocations = _cachedSecondaryAllocations
+        };
+
+        _secondaryBurnAllocationLookup.Clear();
+        foreach (var alloc in _cachedSecondaryAllocations)
+            _secondaryBurnAllocationLookup[alloc.StageNumber] = alloc;
     }
 
     private static void ClearBurnAnalysis()
@@ -130,9 +261,24 @@ static class StageAnalysisCache
         _burnAllocationLookup.Clear();
     }
 
+    private static void ClearSecondaryBurnAnalysis()
+    {
+        _cachedSecondaryBurnAnalysis = null;
+        _secondaryBurnAllocationLookup.Clear();
+    }
+
+    private static void ClearSecondary()
+    {
+        _cachedSecondaryAnalysis = null;
+        _cachedSecondaryStages.Clear();
+        _secondaryStageInfoLookup.Clear();
+        ClearSecondaryBurnAnalysis();
+    }
+
     private static void Clear()
     {
         _cachedAnalysis = null;
+        _cachedPrimaryStages.Clear();
         _stageInfoLookup.Clear();
         ClearBurnAnalysis();
     }

--- a/AdvancedFlightComputer/Features/StageInfo/StageAnalyzer.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using AdvancedFlightComputer.Core;
 using Brutal.Logging;
+using Brutal.Numerics;
 using CommunityToolkit.HighPerformance.Buffers;
 using KSA;
 
@@ -100,7 +101,8 @@ public static class StageAnalyzer
     /// Uses pooled static collections to avoid GC pressure when called every
     /// frame. Safe because all callers run on the main thread.
     /// </summary>
-    public static VehicleBurnAnalysis Analyze(Vehicle vehicle, bool log = false)
+    public static VehicleBurnAnalysis Analyze(Vehicle vehicle,
+        float ambientPressure = 0f, float? surfaceGravityOverride = null, bool log = false)
     {
 #if DEBUG
         long perfStart = DebugConfig.Performance ? Stopwatch.GetTimestamp() : 0;
@@ -120,16 +122,25 @@ public static class StageAnalyzer
         ReadOnlySpan<MoleState> moleStates = vehicle.Parts.Moles.States;
         float currentMass = vehicle.TotalMass;
 
-        double parentMass = vehicle.Parent?.Mass ?? 0.0;
-        double parentRadius = vehicle.Parent?.MeanRadius ?? 1.0;
-        float surfaceGravity = (float)(Constants.GRAVITATIONAL_CONSTANT * parentMass / (parentRadius * parentRadius));
+        float surfaceGravity;
+        if (surfaceGravityOverride.HasValue)
+        {
+            surfaceGravity = surfaceGravityOverride.Value;
+        }
+        else
+        {
+            double parentMass = vehicle.Parent?.Mass ?? 0.0;
+            double parentRadius = vehicle.Parent?.MeanRadius ?? 1.0;
+            surfaceGravity = (float)(Constants.GRAVITATIONAL_CONSTANT * parentMass / (parentRadius * parentRadius));
+        }
 
         if (log)
         {
             DefaultCategory.Log.Debug(
                 $"[AFC] StageAnalyzer: vehicle={vehicle.Id}, totalMass={currentMass:F1} kg, " +
                 $"inertMass={vehicle.InertMass:F1} kg, propellant={vehicle.PropellantMass:F1} kg, " +
-                $"stages={stages.Length}, surfaceG={surfaceGravity:F3} m/s^2");
+                $"stages={stages.Length}, surfaceG={surfaceGravity:F3} m/s^2, " +
+                $"ambientPressure={ambientPressure:F0} Pa");
         }
 
         SortStagesDescending(stages);
@@ -179,10 +190,23 @@ public static class StageAnalyzer
             // Step 3: Aggregate thrust and mass flow rate
             float totalThrust = 0f;
             float totalFlowRate = 0f;
-            foreach (EngineController engine in _pooledEngines)
+            if (ambientPressure > 0f)
             {
-                totalThrust += engine.VacuumData.ThrustMax.Length();
-                totalFlowRate += engine.VacuumData.MassFlowRateMax;
+                foreach (EngineController engine in _pooledEngines)
+                {
+                    var data = RocketControllerData.ComputeFromCores(
+                        engine.Cores.AsSpan(), float3.Zero, ambientPressure);
+                    totalThrust += data.ThrustMax.Length();
+                    totalFlowRate += data.MassFlowRateMax;
+                }
+            }
+            else
+            {
+                foreach (EngineController engine in _pooledEngines)
+                {
+                    totalThrust += engine.VacuumData.ThrustMax.Length();
+                    totalFlowRate += engine.VacuumData.MassFlowRateMax;
+                }
             }
 
             if (totalFlowRate < MinMassFlowRate)

--- a/AdvancedFlightComputer/Features/StageInfo/StageInfoPanel.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageInfoPanel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -14,6 +15,7 @@ namespace AdvancedFlightComputer.Features.StageInfo;
 /// <summary>
 /// Extends the Staging window with per-stage Delta V, TWR, burn time, ISP,
 /// and a fuel progress bar. Also shows total Delta V in a footer.
+/// Supports atmospheric thrust display via configurable display modes.
 ///
 /// Pure rendering code - reads all analysis data from StageAnalysisCache.
 /// Since StagingWindow is a private nested class of Staging, we use manual
@@ -55,6 +57,9 @@ static class StageInfoPanel
     private static MethodInfo? _drawThruster;
     private static MethodInfo? _drawEngine;
     private static MethodInfo? _drawDecoupler;
+
+    private static readonly string[] ModeLabels = { "Auto", "VAC", "ASL", "VAC + ASL", "Planning" };
+    private static bool _initialSizeApplied;
 
     /// <summary>
     /// Applies all StageInfo Harmony patches. Called from Mod.cs after
@@ -114,9 +119,20 @@ static class StageInfoPanel
         if (vehicle == null)
             return false;
 
+        if (!_initialSizeApplied)
+        {
+            _initialSizeApplied = true;
+            float2 screen = ImGui.GetMainViewport().Size;
+            ImGui.SetWindowSize(new float2(screen.X * 0.11f, screen.Y * 0.225f));
+        }
+
         StageAnalysisCache.MarkPanelActive();
 
-        float footerHeight = ImGui.GetTextLineHeightWithSpacing() + 4f;
+        DrawModeSelector();
+
+        bool hasSecondary = StageAnalysisCache.SecondaryAnalysis != null;
+        float footerLines = hasSecondary ? 2f : 1f;
+        float footerHeight = ImGui.GetTextLineHeightWithSpacing() * footerLines + 4f;
         float tableHeight = ImGui.GetContentRegionAvail().Y - footerHeight;
         if (tableHeight < 50f)
             tableHeight = 50f;
@@ -217,6 +233,64 @@ static class StageInfoPanel
 
     #endregion
 
+    #region Mode Selector
+
+    private static void DrawModeSelector()
+    {
+        ImGui.PushItemWidth(110f);
+
+        string currentLabel = ModeLabels[(int)StageInfoSettings.Mode];
+
+        if (ImGui.BeginCombo("##StageInfoMode"u8, currentLabel))
+        {
+            for (int i = 0; i < ModeLabels.Length; i++)
+            {
+                bool isSelected = (int)StageInfoSettings.Mode == i;
+                if (ImGui.Selectable(ModeLabels[i], isSelected))
+                    StageInfoSettings.Mode = (StageDisplayMode)i;
+            }
+            ImGui.EndCombo();
+        }
+        ImGui.PopItemWidth();
+
+        if (StageInfoSettings.Mode == StageDisplayMode.Planning)
+        {
+            ImGui.SameLine();
+            DrawBodySelector();
+        }
+    }
+
+    private static void DrawBodySelector()
+    {
+        List<Astronomical> bodies = StageInfoSettings.GetCelestialBodies();
+        if (bodies.Count == 0)
+        {
+            ImGui.Text("(no bodies)");
+            return;
+        }
+
+        if (StageInfoSettings.SelectedBodyId == null)
+            StageInfoSettings.SelectedBodyId = bodies[0].Id;
+
+        string currentName = StageInfoSettings.SelectedBodyId;
+
+        ImGui.PushItemWidth(140f);
+        if (ImGui.BeginCombo("##PlanningBody"u8, currentName))
+        {
+            for (int i = 0; i < bodies.Count; i++)
+            {
+                string bodyId = bodies[i].Id;
+                bool isSelected = bodyId == StageInfoSettings.SelectedBodyId;
+                if (ImGui.Selectable(bodyId, isSelected))
+                    StageInfoSettings.SelectedBodyId = bodyId;
+            }
+            ImGui.EndCombo();
+        }
+        ImGui.PopItemWidth();
+    }
+
+    #endregion
+
     #region Stage Info Rendering
 
     private static void DrawStageProgressBar(int stageNumber)
@@ -249,40 +323,78 @@ static class StageInfoPanel
         if (!StageAnalysisCache.TryGetStageInfo(stageNumber, out var info)) return;
         if (info.EngineCount == 0) return;
 
+        string primaryLabel = StageAnalysisCache.PrimaryLabel;
+        BurnStageAllocation? primaryAlloc = null;
+        if (StageAnalysisCache.TryGetBurnAllocation(stageNumber, out var pa))
+            primaryAlloc = pa;
+
+        bool hasSecondary = StageAnalysisCache.TryGetSecondaryStageInfo(stageNumber, out var secondaryInfo)
+            && secondaryInfo.EngineCount > 0;
+
+        bool primaryDimmed = hasSecondary && !StageAnalysisCache.IsPrimaryCurrentCondition;
+        DrawSingleStageInfoLine(info, primaryLabel, primaryAlloc, primaryDimmed);
+
+        if (hasSecondary)
+        {
+            string secondaryLabel = StageAnalysisCache.SecondaryLabel ?? "";
+            BurnStageAllocation? secondaryAlloc = null;
+            if (StageAnalysisCache.TryGetSecondaryBurnAllocation(stageNumber, out var sa))
+                secondaryAlloc = sa;
+
+            bool secondaryDimmed = StageAnalysisCache.IsPrimaryCurrentCondition;
+            DrawSingleStageInfoLine(secondaryInfo, secondaryLabel, secondaryAlloc, secondaryDimmed);
+        }
+    }
+
+    private static void DrawSingleStageInfoLine(StageBurnInfo info, string label,
+        BurnStageAllocation? alloc, bool isDimmed)
+    {
         ImGui.TableNextRow();
         ImGui.TableNextColumn();
         ImGui.Indent();
-        ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyleColorVec4(ImGuiCol.TextDisabled));
+
+        if (isDimmed)
+        {
+            var dimColor = ImGui.GetStyleColorVec4(ImGuiCol.TextDisabled);
+            dimColor.W *= 0.6f;
+            ImGui.PushStyleColor(ImGuiCol.Text, dimColor);
+        }
+        else
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyleColorVec4(ImGuiCol.TextDisabled));
+        }
 
         float spacing = ImGui.GetStyle().ItemSpacing.X;
         float availWidth = ImGui.GetContentRegionAvail().X;
         float lineX = 0f;
-
-        string dvText = string.Format(Inv, "Delta V: {0:N0} m/s", info.DeltaV);
-        string twrText = string.Format(Inv, "TWR: {0:F2}", info.Twr);
-        string burnTimeText = string.Format(Inv, "Burn Time: {0}", FormatBurnTime(info.BurnTime));
-        string ispText = string.Format(Inv, "ISP: {0:F0}s", info.Isp);
-
-        BurnStageAllocation? alloc = null;
-        if (StageAnalysisCache.TryGetBurnAllocation(stageNumber, out var a))
-            alloc = a;
 
         if (alloc != null)
         {
             float ratio = alloc.Value.StageTotalDv > 0f
                 ? alloc.Value.AllocatedDv / alloc.Value.StageTotalDv
                 : 1f;
-            ImColor8 burnColor = GetBurnGradientColor(ratio);
+            ImColor8 burnColor = isDimmed
+                ? new ImColor8(180, 180, 180, 160)
+                : GetBurnGradientColor(ratio);
 
-            DrawInfoSegmentColored(dvText, burnColor, ref lineX, availWidth, spacing);
-
-            string needsText = string.Format(Inv, "needs {0:N0} m/s", alloc.Value.AllocatedDv);
-            DrawInfoSegmentColored(needsText, burnColor, ref lineX, availWidth, spacing);
+            string allocText = string.IsNullOrEmpty(label)
+                ? string.Format(Inv, "Burn allocated {0:N0} / {1:N0} m/s stage deltaV",
+                    alloc.Value.AllocatedDv, info.DeltaV)
+                : string.Format(Inv, "{0} Burn allocated {1:N0} / {2:N0} m/s stage deltaV",
+                    label, alloc.Value.AllocatedDv, info.DeltaV);
+            DrawInfoSegmentColored(allocText, burnColor, ref lineX, availWidth, spacing);
         }
         else
         {
+            string dvText = string.IsNullOrEmpty(label)
+                ? string.Format(Inv, "Delta V: {0:N0} m/s", info.DeltaV)
+                : string.Format(Inv, "{0} Delta V: {1:N0} m/s", label, info.DeltaV);
             DrawInfoSegment(dvText, ref lineX, availWidth, spacing, isFirst: true);
         }
+
+        string twrText = string.Format(Inv, "TWR: {0:F2}", info.Twr);
+        string burnTimeText = string.Format(Inv, "Burn: {0}", FormatBurnTime(info.BurnTime));
+        string ispText = string.Format(Inv, "ISP: {0:F0}s", info.Isp);
 
         DrawInfoSegment(twrText, ref lineX, availWidth, spacing, isFirst: false);
         DrawInfoSegment(burnTimeText, ref lineX, availWidth, spacing, isFirst: false);
@@ -326,12 +438,40 @@ static class StageInfoPanel
 
         ImGui.Separator();
 
-        var burnAnalysis = StageAnalysisCache.BurnAnalysis;
+        string primaryLabel = StageAnalysisCache.PrimaryLabel;
+        bool hasSecondary = StageAnalysisCache.SecondaryAnalysis != null;
+        bool primaryDimmed = hasSecondary && !StageAnalysisCache.IsPrimaryCurrentCondition;
+
+        DrawTotalLine(stages, StageAnalysisCache.BurnAnalysis, primaryLabel, primaryDimmed);
+
+        if (hasSecondary)
+        {
+            var secondary = StageAnalysisCache.SecondaryAnalysis!.Value;
+            string secondaryLabel = StageAnalysisCache.SecondaryLabel ?? "";
+            bool secondaryDimmed = StageAnalysisCache.IsPrimaryCurrentCondition;
+
+            DrawTotalLine(secondary, StageAnalysisCache.SecondaryBurnAnalysis,
+                secondaryLabel, secondaryDimmed);
+        }
+    }
+
+    private static void DrawTotalLine(VehicleBurnAnalysis stages, BurnAnalysis? burnAnalysis,
+        string label, bool isDimmed)
+    {
+        if (isDimmed)
+        {
+            var dimColor = ImGui.GetStyleColorVec4(ImGuiCol.TextDisabled);
+            dimColor.W *= 0.6f;
+            ImGui.PushStyleColor(ImGuiCol.Text, dimColor);
+        }
+
+        string prefix = string.IsNullOrEmpty(label) ? "" : label + " ";
+
         if (burnAnalysis != null)
         {
             var burn = burnAnalysis.Value;
             string totalText = string.Format(Inv,
-                "Total Delta V: {0:N0} m/s", stages.TotalDeltaV);
+                "{0}Total Delta V: {1:N0} m/s", prefix, stages.TotalDeltaV);
             ImGui.Text(totalText);
             ImGui.SameLine();
             ImGui.Text("|");
@@ -356,10 +496,13 @@ static class StageInfoPanel
         else
         {
             string totalText = string.Format(Inv,
-                "Total Delta V: {0:N0} m/s  Burn Time: {1}",
-                stages.TotalDeltaV, FormatBurnTime(stages.TotalBurnTime));
+                "{0}Total Delta V: {1:N0} m/s  Burn Time: {2}",
+                prefix, stages.TotalDeltaV, FormatBurnTime(stages.TotalBurnTime));
             ImGui.Text(totalText);
         }
+
+        if (isDimmed)
+            ImGui.PopStyleColor();
     }
 
     #endregion

--- a/AdvancedFlightComputer/Features/StageInfo/StageInfoSettings.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageInfoSettings.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using KSA;
+
+namespace AdvancedFlightComputer.Features.StageInfo;
+
+public enum StageDisplayMode
+{
+    Auto,
+    Vac,
+    Asl,
+    VacAsl,
+    Planning
+}
+
+public readonly record struct AnalysisEnvironment(
+    float PrimaryPressure,
+    float? PrimarySurfaceGravity,
+    float? SecondaryPressure,
+    float? SecondarySurfaceGravity,
+    string PrimaryLabel,
+    string? SecondaryLabel,
+    bool IsPrimaryCurrentCondition
+);
+
+public static class StageInfoSettings
+{
+    public static StageDisplayMode Mode = StageDisplayMode.Auto;
+    public static string? SelectedBodyId;
+
+    private static readonly List<Astronomical> _bodiesCache = new();
+
+    public static AnalysisEnvironment ResolveEnvironment(Vehicle vehicle)
+    {
+        float currentPressure = vehicle.LastKinematicStates.AtmosphericPressure;
+        bool inAtmosphere = currentPressure > 0f;
+
+        return Mode switch
+        {
+            StageDisplayMode.Auto => new AnalysisEnvironment(
+                PrimaryPressure: currentPressure,
+                PrimarySurfaceGravity: null,
+                SecondaryPressure: null,
+                SecondarySurfaceGravity: null,
+                PrimaryLabel: inAtmosphere ? "(ATM)" : "(VAC)",
+                SecondaryLabel: null,
+                IsPrimaryCurrentCondition: true),
+
+            StageDisplayMode.Vac => new AnalysisEnvironment(
+                PrimaryPressure: 0f,
+                PrimarySurfaceGravity: null,
+                SecondaryPressure: null,
+                SecondarySurfaceGravity: null,
+                PrimaryLabel: "(VAC)",
+                SecondaryLabel: null,
+                IsPrimaryCurrentCondition: !inAtmosphere),
+
+            StageDisplayMode.Asl => new AnalysisEnvironment(
+                PrimaryPressure: GetSeaLevelPressure(vehicle.Parent),
+                PrimarySurfaceGravity: null,
+                SecondaryPressure: null,
+                SecondarySurfaceGravity: null,
+                PrimaryLabel: "(ASL)",
+                SecondaryLabel: null,
+                IsPrimaryCurrentCondition: false),
+
+            StageDisplayMode.VacAsl => new AnalysisEnvironment(
+                PrimaryPressure: 0f,
+                PrimarySurfaceGravity: null,
+                SecondaryPressure: GetSeaLevelPressure(vehicle.Parent),
+                SecondarySurfaceGravity: null,
+                PrimaryLabel: "[VAC]",
+                SecondaryLabel: "[ASL]",
+                IsPrimaryCurrentCondition: !inAtmosphere),
+
+            StageDisplayMode.Planning => ResolvePlanningEnvironment(vehicle),
+
+            _ => new AnalysisEnvironment(0f, null, null, null, "(VAC)", null, true)
+        };
+    }
+
+    public static List<Astronomical> GetCelestialBodies()
+    {
+        _bodiesCache.Clear();
+
+        if (Universe.CurrentSystem == null)
+            return _bodiesCache;
+
+        foreach (Astronomical astro in Universe.CurrentSystem.All.GetList())
+        {
+            if (astro is Vehicle)
+                continue;
+            if (astro is IParentBody)
+                _bodiesCache.Add(astro);
+        }
+
+        return _bodiesCache;
+    }
+
+    public static float ComputeSurfaceGravity(IParentBody body)
+    {
+        double r = body.MeanRadius;
+        if (r <= 0.0)
+            return 0f;
+        return (float)(Constants.GRAVITATIONAL_CONSTANT * body.Mass / (r * r));
+    }
+
+    public static float GetSeaLevelPressure(IParentBody? body)
+    {
+        if (body is Astronomical astro)
+        {
+            var atmo = astro.GetAtmosphereReference();
+            if (atmo != null)
+                return (float)(double)atmo.Physical.SeaLevelPressure;
+        }
+        return 0f;
+    }
+
+    public static void Reset()
+    {
+        Mode = StageDisplayMode.Auto;
+        SelectedBodyId = null;
+        _bodiesCache.Clear();
+    }
+
+    private static AnalysisEnvironment ResolvePlanningEnvironment(Vehicle vehicle)
+    {
+        IParentBody? body = FindSelectedBody();
+        if (body == null)
+        {
+            return new AnalysisEnvironment(0f, null, null, null, "(VAC)", null, true);
+        }
+
+        float pressure = GetSeaLevelPressure(body);
+        float gravity = ComputeSurfaceGravity(body);
+        bool hasAtmosphere = pressure > 0f;
+        string bodyName = (body as Astronomical)?.Id ?? "?";
+        string label = hasAtmosphere
+            ? $"({bodyName} ASL)"
+            : $"({bodyName})";
+
+        return new AnalysisEnvironment(
+            PrimaryPressure: pressure,
+            PrimarySurfaceGravity: gravity,
+            SecondaryPressure: null,
+            SecondarySurfaceGravity: null,
+            PrimaryLabel: label,
+            SecondaryLabel: null,
+            IsPrimaryCurrentCondition: false);
+    }
+
+    private static IParentBody? FindSelectedBody()
+    {
+        if (SelectedBodyId == null || Universe.CurrentSystem == null)
+            return null;
+
+        foreach (Astronomical astro in Universe.CurrentSystem.All.GetList())
+        {
+            if (astro is Vehicle)
+                continue;
+            if (astro is IParentBody body && astro.Id == SelectedBodyId)
+                return body;
+        }
+
+        return null;
+    }
+}

--- a/AdvancedFlightComputer/Mod.cs
+++ b/AdvancedFlightComputer/Mod.cs
@@ -71,6 +71,7 @@ public class Mod
         Patch_AutoStageExecution.Reset();
         StageAnalyzerDebug.Reset();
         StageAnalysisCache.Reset();
+        StageInfoSettings.Reset();
         CorrectedBurnState.Clear();
         StageAnalyzer.ResetPools();
         LogHelper.Reset();


### PR DESCRIPTION
Summary

  - Stage Info now computes TWR, ISP, and Delta-V using atmospheric pressure instead of only vacuum values
  - Adds display mode selector (Auto / VAC / ASL / VAC+ASL / Planning) above the staging table
  - Planning mode lets you select any celestial body to preview stage performance with that body's pressure and surface gravity
  - VAC+ASL mode shows both values side by side, dimming the one not matching current conditions
  - Updated burn allocation format to "Burn allocated X / Y m/s stage deltaV"

Closes #2