### PR TITLE
Update for KSA v2026.2.38.3713

### DIFF
--- a/AdvancedFlightComputer/Features/StageInfo/StageAnalyzer.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageAnalyzer.cs
@@ -503,16 +503,19 @@ public static class StageAnalyzer
     {
         float current = 0f;
         float max = 0f;
-        MemoryOwner<ArrayPoolResult<Tank>> nodes =
+        MemoryOwner<MemoryOwner<Tank>>? nodes =
             resourceManager.FurtherestToNearestNodeSameStage;
 
-        if (nodes.Length == 0)
+        if (nodes == null || nodes.Length == 0)
             return (0f, 0f);
 
-        Span<ArrayPoolResult<Tank>> nodeSpan = nodes.Span;
+        Span<MemoryOwner<Tank>> nodeSpan = nodes.Span;
         for (int i = 0; i < nodeSpan.Length; i++)
         {
-            Span<Tank> tanks = nodeSpan[i].AsSpan();
+            if (nodeSpan[i].Length == 0)
+                continue;
+
+            Span<Tank> tanks = nodeSpan[i].Span;
             for (int j = 0; j < tanks.Length; j++)
             {
                 Tank tank = tanks[j];

--- a/AdvancedFlightComputer/Mod.cs
+++ b/AdvancedFlightComputer/Mod.cs
@@ -14,7 +14,7 @@ public class Mod
 {
     private static Harmony? _harmony;
 
-    private const string TestedGameVersion = "v2026.2.37.3699";
+    private const string TestedGameVersion = "v2026.2.38.3713";
 
     public static bool DebugMode => DebugConfig.Any;
 


### PR DESCRIPTION
## Summary
- Fix compile-breaking change in `StageAnalyzer.WalkSameStage`: the game's
  `ResourceManagerBase` changed flow rule storage from `MemoryOwner<ArrayPoolResult<T>>`
  to nullable `MemoryOwner<MemoryOwner<T>>?`
- Add null/empty guards for the new nullable 2D MemoryOwner structure
- Bump `TestedGameVersion` to v2026.2.38.3713