### PR TITLE
Add Maneuver Quick-Tools Feature

### DIFF
--- a/AdvancedFlightComputer/Core/DebugConfig.cs
+++ b/AdvancedFlightComputer/Core/DebugConfig.cs
@@ -12,14 +12,16 @@ static class DebugConfig
     public static bool HyperbolicTargets = true;
     public static bool AutoStage = true;
     public static bool StageInfo = true;
+    public static bool ManeuverTools = true;
     public static bool Performance = true;
 #else
     public static bool HyperbolicTargets = false;
     public static bool AutoStage = false;
     public static bool StageInfo = false;
+    public static bool ManeuverTools = false;
     public static bool Performance = false;
 #endif
 
     public static bool Any =>
-        HyperbolicTargets || AutoStage || StageInfo || Performance;
+        HyperbolicTargets || AutoStage || StageInfo || ManeuverTools || Performance;
 }

--- a/AdvancedFlightComputer/Core/GameReflection.cs
+++ b/AdvancedFlightComputer/Core/GameReflection.cs
@@ -55,6 +55,25 @@ static class GameReflection
 
     #endregion
 
+    #region ManeuverTools
+
+    public static readonly FieldInfo? TransferPlanner_transferType =
+        AccessTools.Field(typeof(TransferPlanner), "_transferType");
+    public static readonly FieldInfo? TransferPlanner_transferCalculated =
+        AccessTools.Field(typeof(TransferPlanner), "_transferCalculated");
+    public static readonly FieldInfo? TransferPlanner_transferBeingCalculated =
+        AccessTools.Field(typeof(TransferPlanner), "_transferBeingCalculated");
+    public static readonly FieldInfo? TransferPlanner_transferBurn =
+        AccessTools.Field(typeof(TransferPlanner), "_transferBurn");
+    public static readonly FieldInfo? TransferPlanner_correctionTime =
+        AccessTools.Field(typeof(TransferPlanner), "_correctionTime");
+    public static readonly FieldInfo? TransferPlanner_showPlanWindow =
+        AccessTools.Field(typeof(TransferPlanner), "_showPlanWindow");
+    public static readonly MethodInfo? TransferPlanner_SetTransferInfo =
+        AccessTools.Method(typeof(TransferPlanner), "SetTransferInfo");
+
+    #endregion
+
     #region Validation
 
     public static bool ValidateHyperbolicTargets()
@@ -90,6 +109,24 @@ static class GameReflection
             ("StagingWindow.DrawComponent", StagingWindow_DrawComponentOpen),
         };
         return ValidateTargets("StageInfo", targets);
+    }
+
+    public static bool ValidateManeuverTools()
+    {
+        var targets = new (string name, object? target)[]
+        {
+            ("TransferPlanner._sourceBody",              TransferPlanner_sourceBody),
+            ("TransferPlanner._transferInfo",             TransferPlanner_transferInfo),
+            ("TransferPlanner._selectedEntry",            TransferPlanner_selectedEntry),
+            ("TransferPlanner._transferType",             TransferPlanner_transferType),
+            ("TransferPlanner._transferCalculated",       TransferPlanner_transferCalculated),
+            ("TransferPlanner._transferBeingCalculated",  TransferPlanner_transferBeingCalculated),
+            ("TransferPlanner._transferBurn",             TransferPlanner_transferBurn),
+            ("TransferPlanner._correctionTime",           TransferPlanner_correctionTime),
+            ("TransferPlanner._showPlanWindow",           TransferPlanner_showPlanWindow),
+            ("TransferPlanner.SetTransferInfo",          TransferPlanner_SetTransferInfo),
+        };
+        return ValidateTargets("ManeuverTools", targets);
     }
 
     private static bool ValidateTargets(string feature, (string name, object? target)[] targets)

--- a/AdvancedFlightComputer/Features/ManeuverTools/DrawPlanWindowPatch.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/DrawPlanWindowPatch.cs
@@ -111,12 +111,15 @@ static class Patch_DrawPlanWindow
             ImGui.Spacing();
             DrawCreateButton(source, result.Value);
 
-            ImGui.Separator();
-            ImGuiHelper.BeginColumns(2, new float[] { 0.9f });
-            ImGuiHelper.DrawCheckbox("Preview Orbit"u8, ref _showOrbitPreview, isChanged: false);
-            ImGuiHelper.DrawCheckbox("Preview Flight Plan"u8, ref _showFlightPlanPreview,
-                isChanged: false);
-            ImGuiHelper.EndColumns();
+            if (_ourBurn == null)
+            {
+                ImGui.Separator();
+                ImGuiHelper.BeginColumns(2, new float[] { 0.9f });
+                ImGuiHelper.DrawCheckbox("Preview Orbit"u8, ref _showOrbitPreview, isChanged: false);
+                ImGuiHelper.DrawCheckbox("Preview Flight Plan"u8, ref _showFlightPlanPreview,
+                    isChanged: false);
+                ImGuiHelper.EndColumns();
+            }
         }
         else
         {
@@ -261,7 +264,7 @@ static class Patch_DrawPlanWindow
     /// </summary>
     internal static void RenderOrbitPreview(Viewport inViewport)
     {
-        if (!_showOrbitPreview || _lastEntry == null || _lastSource == null)
+        if (!_showOrbitPreview || _ourBurn != null || _lastEntry == null || _lastSource == null)
             return;
 
         FlightPlan fp = _lastEntry.FlightPlan;
@@ -306,6 +309,13 @@ static class Patch_DrawPlanWindow
             if (targetOrbit == null) return null;
             return OrbitManeuvers.ComputeMatchInclination(
                 orbit, targetOrbit, ManeuverToolsWindow.UseDescendingNode, now);
+        }
+
+        if (key == ManeuverTools.KeySetInclination)
+        {
+            return OrbitManeuvers.ComputeSetInclination(
+                orbit, ManeuverToolsWindow.TargetInclinationRad,
+                ManeuverToolsWindow.UseDescendingNode, now);
         }
 
         return null;

--- a/AdvancedFlightComputer/Features/ManeuverTools/DrawPlanWindowPatch.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/DrawPlanWindowPatch.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using AdvancedFlightComputer.Core;
+using Brutal.ImGuiApi;
+using Brutal.Logging;
+using Brutal.Numerics;
+using CommunityToolkit.HighPerformance.Buffers;
+using HarmonyLib;
+using KSA;
+
+namespace AdvancedFlightComputer.Features.ManeuverTools;
+
+/// <summary>
+/// Prefix on TransferPlanner.DrawPlanWindow that takes over the entire window
+/// when one of our plan types is selected. Draws the Plan Type dropdown, Source
+/// dropdown, type-specific controls, and Create button all inside the stock
+/// "Transfer Planning" window.
+///
+/// Returns false (skip original) for our types, true for stock types.
+/// </summary>
+[HarmonyPatch(typeof(TransferPlanner), nameof(TransferPlanner.DrawPlanWindow))]
+static class Patch_DrawPlanWindow
+{
+    private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+
+    private static Burn? _ourBurn;
+    private static OrbitalTransfers.PorkChopEntry? _lastEntry;
+    private static Vehicle? _lastSource;
+    private static bool _showFlightPlanPreview;
+    private static bool _showOrbitPreview;
+
+    static bool Prefix(Viewport inViewport)
+    {
+        try
+        {
+            var transferType = (TransferType)GameReflection.TransferPlanner_transferType!.GetValue(null)!;
+            if (!ManeuverTools.IsOurType(transferType.GetKey()))
+            {
+                _ourBurn = null;
+                _lastEntry = null;
+                _lastSource = null;
+                return true;
+            }
+
+            DrawWindow(inViewport, transferType);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            DefaultCategory.Log.Warning($"[AFC] ManeuverTools Prefix: {ex.Message}");
+            return true;
+        }
+    }
+
+    private static void DrawWindow(Viewport inViewport, TransferType transferType)
+    {
+        CleanupStaleBurn();
+
+        ImGui.SetNextWindowPos(
+            inViewport.Position + new float2(inViewport.Size.X - 440, 50f),
+            ImGuiCond.Appearing, (float2?)null);
+        ImGui.SetNextWindowSize(new float2(400f, 600f), ImGuiCond.Appearing);
+
+        bool pOpen = (bool)GameReflection.TransferPlanner_showPlanWindow!.GetValue(null)!;
+        if (!ImGui.Begin("Transfer Planning"u8, ref pOpen,
+                ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoCollapse
+                | ImGuiWindowFlags.NoSavedSettings))
+        {
+            if (!pOpen) HandleWindowClose();
+            ImGui.End();
+            return;
+        }
+        if (!pOpen)
+        {
+            HandleWindowClose();
+            ImGui.End();
+            return;
+        }
+        GameReflection.TransferPlanner_showPlanWindow!.SetValue(null, true);
+
+        if (!DrawPlanTypeDropdown(ref transferType))
+        {
+            ImGui.End();
+            return;
+        }
+
+        ImGui.Text(""u8);
+
+        Vehicle? source = DrawSourceDropdown();
+        if (source?.Orbit == null)
+        {
+            ImGui.End();
+            return;
+        }
+        _lastSource = source;
+
+        ImGui.Separator();
+
+        ManeuverToolsWindow.DrawInline(transferType.GetKey(), source);
+
+        var result = ComputeManeuver(transferType.GetKey(), source);
+        if (result != null)
+        {
+            var (entry, _) = OrbitManeuvers.BuildTransferEntry(source, result.Value);
+            _lastEntry = entry;
+
+            ImGui.Separator();
+            DrawManeuverInfo(result.Value);
+
+            ImGui.Spacing();
+            DrawCreateButton(source, result.Value);
+
+            ImGui.Separator();
+            ImGuiHelper.BeginColumns(2, new float[] { 0.9f });
+            ImGuiHelper.DrawCheckbox("Preview Orbit"u8, ref _showOrbitPreview, isChanged: false);
+            ImGuiHelper.DrawCheckbox("Preview Flight Plan"u8, ref _showFlightPlanPreview,
+                isChanged: false);
+            ImGuiHelper.EndColumns();
+        }
+        else
+        {
+            _lastEntry = null;
+        }
+
+        ImGui.End();
+
+        if (_showFlightPlanPreview && _lastEntry != null)
+            DrawFlightPlanWindow(inViewport);
+    }
+
+    #region Dropdowns
+
+    private static bool DrawPlanTypeDropdown(ref TransferType transferType)
+    {
+        TransferType prev = transferType;
+        if (ImGuiHelper.DrawCombo("Plan Type:"u8, ref transferType, TransferPlanner.TransferTypes)
+            && transferType.GetKey() != prev.GetKey())
+        {
+            GameReflection.TransferPlanner_transferType!.SetValue(null, transferType);
+            GameReflection.TransferPlanner_transferCalculated!.SetValue(null, false);
+            ManeuverToolsWindow.OnTypeChanged();
+
+            if (!ManeuverTools.IsOurType(transferType.GetKey()))
+            {
+                GameReflection.TransferPlanner_SetTransferInfo!.Invoke(null, null);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Vehicle? DrawSourceDropdown()
+    {
+        var sourceBody = (TransferObject)GameReflection.TransferPlanner_sourceBody!.GetValue(null)!;
+        var vehicleList = new List<TransferObject>();
+        foreach (Vehicle v in Universe.CurrentSystem!.Vehicles.GetList())
+            vehicleList.Add(new TransferObject(v));
+
+        if (ImGui.IsWindowAppearing() || sourceBody.GetKey() == "N/A")
+        {
+            if (Program.ControlledVehicle != null)
+            {
+                int idx = vehicleList.FindIndex(v => v.GetKey() == Program.ControlledVehicle.Id);
+                if (idx > -1)
+                    sourceBody = vehicleList[idx];
+            }
+            else if (vehicleList.Count > 0)
+                sourceBody = vehicleList[0];
+            else
+                sourceBody = default;
+
+            GameReflection.TransferPlanner_sourceBody!.SetValue(null, sourceBody);
+        }
+
+        TransferObject prev = sourceBody;
+        if (ImGuiHelper.DrawCombo("Source:"u8, ref sourceBody, vehicleList)
+            && sourceBody.GetKey() != prev.GetKey())
+        {
+            GameReflection.TransferPlanner_sourceBody!.SetValue(null, sourceBody);
+            ManeuverToolsWindow.OnSourceChanged();
+        }
+
+        return sourceBody.Body as Vehicle;
+    }
+
+    #endregion
+
+    #region Maneuver Info + Create
+
+    private static void DrawManeuverInfo(OrbitManeuvers.ManeuverResult maneuver)
+    {
+        double dvMag = maneuver.DvCci.Length();
+        double timeToNode = maneuver.BurnTime.Seconds() - Universe.GetElapsedSimTime().Seconds();
+
+        ImGuiHelper.DrawTextWidget("Required Delta V:"u8,
+            string.Format(Inv, "{0:F1} m/s", dvMag));
+
+        if (timeToNode > 0)
+        {
+            ImGuiHelper.DrawTextWidget("Time to Burn:"u8,
+                ManeuverToolsWindow.FormatTimeSpan(timeToNode));
+        }
+    }
+
+    private static void DrawFlightPlanWindow(Viewport inViewport)
+    {
+        ImGui.SetNextWindowPos(
+            inViewport.Position + new float2(620f, 40f),
+            ImGuiCond.Appearing, (float2?)null);
+        ImGui.SetNextWindowSize(new float2(460f, 620f), ImGuiCond.Appearing);
+
+        if (ImGui.Begin("Maneuver Flight Plan"u8, ref _showFlightPlanPreview,
+                ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoFocusOnAppearing))
+        {
+            _lastEntry!.FlightPlan.DrawPatchInfo();
+        }
+        ImGui.End();
+    }
+
+    private static void DrawCreateButton(Vehicle source, OrbitManeuvers.ManeuverResult maneuver)
+    {
+        if (_ourBurn != null)
+        {
+            if (_ourBurn.Time < Universe.GetElapsedSimTime())
+            {
+                _ourBurn = null;
+            }
+            else
+            {
+                ImGui.PushStyleColor(ImGuiCol.Text, new ImColor8(120, 120, 120, 255));
+                ImGui.Text("Maneuver node created."u8);
+                ImGui.PopStyleColor();
+                return;
+            }
+        }
+
+        if (ImGuiHelper.DrawButton("Create"u8, KSAColor.DarkGrey,
+                KSAColor.Xkcd.DustyBlue, Color.Green))
+        {
+            PatchedConic? patch = source.FlightPlan.TryFindPatch(maneuver.BurnTime);
+            if (patch != null)
+            {
+                OrbitPointCce point = patch.Orbit.GetPointAt(maneuver.BurnTime);
+                _ourBurn = Burn.Create(point, maneuver.BurnTime.Seconds(),
+                    maneuver.DvVlf, patch, source);
+                source.FlightComputer.AddBurn(_ourBurn);
+                _ourBurn.IsGizmoActive = false;
+            }
+        }
+    }
+
+    #endregion
+
+    #region Visual Orbit Preview
+
+    /// <summary>
+    /// Renders the post-burn orbit in the 3D view. Called from
+    /// Patch_OnPreRender when our type is active and preview is enabled.
+    /// Follows the same pattern as stock DrawSelectedTransfer.
+    /// </summary>
+    internal static void RenderOrbitPreview(Viewport inViewport)
+    {
+        if (!_showOrbitPreview || _lastEntry == null || _lastSource == null)
+            return;
+
+        FlightPlan fp = _lastEntry.FlightPlan;
+        if (fp.Patches.Count == 0)
+            return;
+
+        if (fp.Patches[0].Orbit.IsMissingPoints())
+        {
+            foreach (PatchedConic patch in fp.Patches)
+            {
+                patch.HidePatch = false;
+                MemoryOwner<OrbitPointCce> points = UpdateTaskUtils.GenerateSpacedPoints(patch);
+                patch.Orbit.UpdateCachedPoints(points);
+            }
+        }
+
+        fp.AddLineInstances(inViewport, _lastSource, isActive: true,
+            drawVehiclePosition: false, TrueAnomaly.NaN, TrueAnomaly.NaN);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static OrbitManeuvers.ManeuverResult? ComputeManeuver(string key, Vehicle source)
+    {
+        Orbit orbit = source.Orbit;
+        double parentRadius = source.Parent?.MeanRadius ?? 0.0;
+        SimTime now = Universe.GetElapsedSimTime();
+
+        if (key == ManeuverTools.KeySetPeriapsis)
+            return OrbitManeuvers.ComputeSetPeriapsis(
+                orbit, ManeuverToolsWindow.TargetAltitude, parentRadius, now);
+
+        if (key == ManeuverTools.KeySetApoapsis)
+            return OrbitManeuvers.ComputeSetApoapsis(
+                orbit, ManeuverToolsWindow.TargetAltitude, parentRadius, now);
+
+        if (key == ManeuverTools.KeyMatchInclination)
+        {
+            Orbit? targetOrbit = ManeuverToolsWindow.GetSelectedTargetOrbit();
+            if (targetOrbit == null) return null;
+            return OrbitManeuvers.ComputeMatchInclination(
+                orbit, targetOrbit, ManeuverToolsWindow.UseDescendingNode, now);
+        }
+
+        return null;
+    }
+
+    private static void CleanupStaleBurn()
+    {
+        if (_ourBurn == null) return;
+
+        Vehicle? source = (_ourBurn.Vehicle != null
+            && _ourBurn.Vehicle.FlightComputer.BurnPlan.TryGetBurn(_ourBurn))
+            ? _ourBurn.Vehicle : null;
+
+        if (source == null)
+            _ourBurn = null;
+    }
+
+    private static void HandleWindowClose()
+    {
+        GameReflection.TransferPlanner_showPlanWindow!.SetValue(null, false);
+        GameReflection.TransferPlanner_transferCalculated!.SetValue(null, false);
+        GameReflection.TransferPlanner_selectedEntry!.SetValue(null, null);
+        GameReflection.TransferPlanner_transferBurn!.SetValue(null, null);
+        _ourBurn = null;
+        _lastEntry = null;
+        _lastSource = null;
+    }
+
+    internal static void Reset()
+    {
+        _ourBurn = null;
+        _lastEntry = null;
+        _lastSource = null;
+        _showFlightPlanPreview = false;
+        _showOrbitPreview = false;
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Postfix on TransferPlanner.OnPreRender to render the visual orbit preview
+/// in the 3D view when one of our plan types is active.
+/// </summary>
+[HarmonyPatch(typeof(TransferPlanner), nameof(TransferPlanner.OnPreRender))]
+static class Patch_OnPreRender
+{
+    static void Postfix(Viewport inViewport)
+    {
+        try
+        {
+            Patch_DrawPlanWindow.RenderOrbitPreview(inViewport);
+        }
+        catch (Exception ex)
+        {
+            DefaultCategory.Log.Warning($"[AFC] ManeuverTools OnPreRender: {ex.Message}");
+        }
+    }
+}

--- a/AdvancedFlightComputer/Features/ManeuverTools/ManeuverTools.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/ManeuverTools.cs
@@ -6,15 +6,16 @@ using KSA;
 namespace AdvancedFlightComputer.Features.ManeuverTools;
 
 /// <summary>
-/// Adds maneuver quick-tools (Set Periapsis, Set Apoapsis, Match Inclination)
-/// to the stock Transfer Planner dropdown. Each tool computes a single burn
-/// via vis-viva or plane-change math and creates a standard maneuver node.
+/// Adds maneuver quick-tools (Set Periapsis, Set Apoapsis, Match Inclination,
+/// Set Inclination) to the stock Transfer Planner dropdown. Each tool computes
+/// a single burn via vis-viva or plane-change math and creates a maneuver node.
 /// </summary>
 static class ManeuverTools
 {
     internal const string KeySetPeriapsis = "AFC Set Periapsis";
     internal const string KeySetApoapsis = "AFC Set Apoapsis";
     internal const string KeyMatchInclination = "AFC Match Inclination";
+    internal const string KeySetInclination = "AFC Set Inclination";
 
     /// <summary>
     /// Adds our plan types to the stock TransferPlanner dropdown.
@@ -31,10 +32,11 @@ static class ManeuverTools
         types.Add(new TransferType(KeySetPeriapsis, "Set Periapsis"));
         types.Add(new TransferType(KeySetApoapsis, "Set Apoapsis"));
         types.Add(new TransferType(KeyMatchInclination, "Match Inclination"));
+        types.Add(new TransferType(KeySetInclination, "Set Inclination"));
 
         if (DebugConfig.ManeuverTools)
             DefaultCategory.Log.Debug(
-                $"[AFC] ManeuverTools: injected 3 transfer types ({types.Count} total).");
+                $"[AFC] ManeuverTools: injected 4 transfer types ({types.Count} total).");
     }
 
     /// <summary>
@@ -44,7 +46,8 @@ static class ManeuverTools
     {
         return key == KeySetPeriapsis
             || key == KeySetApoapsis
-            || key == KeyMatchInclination;
+            || key == KeyMatchInclination
+            || key == KeySetInclination;
     }
 
     /// <summary>

--- a/AdvancedFlightComputer/Features/ManeuverTools/ManeuverTools.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/ManeuverTools.cs
@@ -1,0 +1,62 @@
+using AdvancedFlightComputer.Core;
+using Brutal.Logging;
+using HarmonyLib;
+using KSA;
+
+namespace AdvancedFlightComputer.Features.ManeuverTools;
+
+/// <summary>
+/// Adds maneuver quick-tools (Set Periapsis, Set Apoapsis, Match Inclination)
+/// to the stock Transfer Planner dropdown. Each tool computes a single burn
+/// via vis-viva or plane-change math and creates a standard maneuver node.
+/// </summary>
+static class ManeuverTools
+{
+    internal const string KeySetPeriapsis = "AFC Set Periapsis";
+    internal const string KeySetApoapsis = "AFC Set Apoapsis";
+    internal const string KeyMatchInclination = "AFC Match Inclination";
+
+    /// <summary>
+    /// Adds our plan types to the stock TransferPlanner dropdown.
+    /// Called from Mod.OnFullyLoaded before patches are applied.
+    /// Idempotent - checks for existing entries before adding.
+    /// </summary>
+    public static void InjectTransferTypes()
+    {
+        var types = TransferPlanner.TransferTypes;
+
+        if (types.Exists(t => t.GetKey() == KeySetPeriapsis))
+            return;
+
+        types.Add(new TransferType(KeySetPeriapsis, "Set Periapsis"));
+        types.Add(new TransferType(KeySetApoapsis, "Set Apoapsis"));
+        types.Add(new TransferType(KeyMatchInclination, "Match Inclination"));
+
+        if (DebugConfig.ManeuverTools)
+            DefaultCategory.Log.Debug(
+                $"[AFC] ManeuverTools: injected 3 transfer types ({types.Count} total).");
+    }
+
+    /// <summary>
+    /// Returns true if the given transfer type key is one of ours.
+    /// </summary>
+    internal static bool IsOurType(string key)
+    {
+        return key == KeySetPeriapsis
+            || key == KeySetApoapsis
+            || key == KeyMatchInclination;
+    }
+
+    /// <summary>
+    /// Applies all ManeuverTools Harmony patches. Called from Mod.cs
+    /// after GameReflection.ValidateManeuverTools() passes.
+    /// </summary>
+    public static void ApplyPatches(Harmony harmony)
+    {
+        harmony.CreateClassProcessor(typeof(Patch_DrawPlanWindow)).Patch();
+        harmony.CreateClassProcessor(typeof(Patch_OnPreRender)).Patch();
+
+        if (DebugConfig.ManeuverTools)
+            DefaultCategory.Log.Debug("[AFC] ManeuverTools: all patches applied.");
+    }
+}

--- a/AdvancedFlightComputer/Features/ManeuverTools/ManeuverToolsWindow.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/ManeuverToolsWindow.cs
@@ -12,10 +12,10 @@ namespace AdvancedFlightComputer.Features.ManeuverTools;
 /// Transfer Planning window by DrawPlanWindowPatch.
 ///
 /// - Set Periapsis / Set Apoapsis: altitude input, current orbit info, post-burn orbit
-/// - Match Inclination: target dropdown, Set Target, AN/DN radio buttons with tooltips
+/// - Match Inclination: target matching with AN/DN selection
+/// - Set Inclination: arbitrary angle with AN/DN relative to equatorial plane
 ///
-/// Static state (TargetAltitude, UseDescendingNode) is read by DrawPlanWindowPatch
-/// to compute the maneuver in the same frame.
+/// Static state is read by DrawPlanWindowPatch to compute the maneuver in the same frame.
 /// </summary>
 static class ManeuverToolsWindow
 {
@@ -25,17 +25,21 @@ static class ManeuverToolsWindow
 
     public static double TargetAltitude;
     public static bool UseDescendingNode;
+    public static double TargetInclinationRad;
 
     #endregion
 
     #region Internal State
 
     private static double _inputAltitudeKm;
+    private static double _inputInclinationDeg;
     private static bool _defaultsInitialized;
+    private static bool _nodeDefaultInitialized;
     private static string? _lastSourceId;
 
     private static TransferObject _selectedTarget;
     private static List<TransferObject>? _targetList;
+    private static int _lastObjectCount;
     private static bool _setTarget;
 
     #endregion
@@ -46,15 +50,18 @@ static class ManeuverToolsWindow
         {
             _lastSourceId = source.Id;
             _defaultsInitialized = false;
+            _nodeDefaultInitialized = false;
             _targetList = null;
         }
 
         if (typeKey == ManeuverTools.KeySetPeriapsis)
-            DrawSetPeriapsis(source);
+            DrawSetApse(source, isSetPeriapsis: true);
         else if (typeKey == ManeuverTools.KeySetApoapsis)
-            DrawSetApoapsis(source);
+            DrawSetApse(source, isSetPeriapsis: false);
         else if (typeKey == ManeuverTools.KeyMatchInclination)
             DrawMatchInclination(source);
+        else if (typeKey == ManeuverTools.KeySetInclination)
+            DrawSetInclination(source);
     }
 
     public static Orbit? GetSelectedTargetOrbit()
@@ -65,12 +72,14 @@ static class ManeuverToolsWindow
     public static void OnTypeChanged()
     {
         _defaultsInitialized = false;
+        _nodeDefaultInitialized = false;
         _targetList = null;
     }
 
     public static void OnSourceChanged()
     {
         _defaultsInitialized = false;
+        _nodeDefaultInitialized = false;
         _targetList = null;
     }
 
@@ -78,17 +87,21 @@ static class ManeuverToolsWindow
     {
         TargetAltitude = 0.0;
         UseDescendingNode = false;
+        TargetInclinationRad = 0.0;
         _inputAltitudeKm = 0.0;
+        _inputInclinationDeg = 0.0;
         _defaultsInitialized = false;
+        _nodeDefaultInitialized = false;
         _lastSourceId = null;
         _selectedTarget = default;
         _targetList = null;
+        _lastObjectCount = 0;
         _setTarget = false;
     }
 
-    #region Set Periapsis
+    #region Set Periapsis / Set Apoapsis
 
-    private static void DrawSetPeriapsis(Vehicle source)
+    private static void DrawSetApse(Vehicle source, bool isSetPeriapsis)
     {
         Orbit orbit = source.Orbit;
         double parentRadius = source.Parent?.MeanRadius ?? 0.0;
@@ -97,7 +110,7 @@ static class ManeuverToolsWindow
 
         if (!_defaultsInitialized)
         {
-            _inputAltitudeKm = currentPeAlt / 1000.0;
+            _inputAltitudeKm = (isSetPeriapsis ? currentPeAlt : currentApAlt) / 1000.0;
             _defaultsInitialized = true;
         }
 
@@ -107,71 +120,44 @@ static class ManeuverToolsWindow
             return;
         }
 
-        DrawAltitudeInput("Target Periapsis (km):");
+        string inputLabel = isSetPeriapsis ? "Target Periapsis (km):" : "Target Apoapsis (km):";
+        DrawAltitudeInput(inputLabel);
         TargetAltitude = _inputAltitudeKm * 1000.0;
+
+        string burnLocation = isSetPeriapsis ? "Apoapsis" : "Periapsis";
 
         ImGui.Spacing();
         ImGuiHelper.DrawTextWidget("Current Periapsis:"u8, FormatDistance(currentPeAlt));
         ImGuiHelper.DrawTextWidget("Current Apoapsis:"u8, FormatDistance(currentApAlt));
-        ImGuiHelper.DrawTextWidget("Burn Location:"u8, "Apoapsis");
+        ImGuiHelper.DrawTextWidget("Burn Location:"u8, burnLocation);
         if (ImGui.IsItemHovered())
-            ImGui.SetTooltip("Burns at apoapsis change the periapsis on the opposite\nside of the orbit. This is the most fuel-efficient point\nto lower or raise your periapsis."u8);
+        {
+            if (isSetPeriapsis)
+                ImGui.SetTooltip("Burns at apoapsis change the periapsis on the opposite\nside of the orbit. This is the most fuel-efficient point\nto lower or raise your periapsis."u8);
+            else
+                ImGui.SetTooltip("Burns at periapsis change the apoapsis on the opposite\nside of the orbit. This is the most fuel-efficient point\nto lower or raise your apoapsis."u8);
+        }
 
-        if (_inputAltitudeKm >= currentApAlt / 1000.0 - 1.0)
+        bool invalid = isSetPeriapsis
+            ? _inputAltitudeKm >= currentApAlt / 1000.0 - 1.0
+            : _inputAltitudeKm <= currentPeAlt / 1000.0 + 1.0;
+
+        if (invalid)
         {
             ImGui.Spacing();
             ImGui.PushStyleColor(ImGuiCol.Text, new ImColor8(255, 200, 60, 255));
-            ImGui.Text("Target must be below current apoapsis."u8);
+            ImGui.Text(isSetPeriapsis
+                ? "Target must be below current apoapsis."u8
+                : "Target must be above current periapsis."u8);
             ImGui.PopStyleColor();
             return;
         }
 
-        DrawPostBurnOrbitInfo(orbit.Apoapsis, TargetAltitude + parentRadius, orbit.Mu, parentRadius);
-    }
-
-    #endregion
-
-    #region Set Apoapsis
-
-    private static void DrawSetApoapsis(Vehicle source)
-    {
-        Orbit orbit = source.Orbit;
-        double parentRadius = source.Parent?.MeanRadius ?? 0.0;
-        double currentPeAlt = Math.Max(0.0, orbit.Periapsis - parentRadius);
-        double currentApAlt = Math.Max(0.0, orbit.Apoapsis - parentRadius);
-
-        if (!_defaultsInitialized)
-        {
-            _inputAltitudeKm = currentApAlt / 1000.0;
-            _defaultsInitialized = true;
-        }
-
-        if (orbit.Eccentricity >= 1.0)
-        {
-            ImGui.Text("Requires a bound (elliptical) orbit."u8);
-            return;
-        }
-
-        DrawAltitudeInput("Target Apoapsis (km):");
-        TargetAltitude = _inputAltitudeKm * 1000.0;
-
-        ImGui.Spacing();
-        ImGuiHelper.DrawTextWidget("Current Periapsis:"u8, FormatDistance(currentPeAlt));
-        ImGuiHelper.DrawTextWidget("Current Apoapsis:"u8, FormatDistance(currentApAlt));
-        ImGuiHelper.DrawTextWidget("Burn Location:"u8, "Periapsis");
-        if (ImGui.IsItemHovered())
-            ImGui.SetTooltip("Burns at periapsis change the apoapsis on the opposite\nside of the orbit. This is the most fuel-efficient point\nto lower or raise your apoapsis."u8);
-
-        if (_inputAltitudeKm <= currentPeAlt / 1000.0 + 1.0)
-        {
-            ImGui.Spacing();
-            ImGui.PushStyleColor(ImGuiCol.Text, new ImColor8(255, 200, 60, 255));
-            ImGui.Text("Target must be above current periapsis."u8);
-            ImGui.PopStyleColor();
-            return;
-        }
-
-        DrawPostBurnOrbitInfo(TargetAltitude + parentRadius, orbit.Periapsis, orbit.Mu, parentRadius);
+        double newRadius = TargetAltitude + parentRadius;
+        if (isSetPeriapsis)
+            DrawPostBurnOrbitInfo(orbit.Apoapsis, newRadius, orbit.Mu, parentRadius);
+        else
+            DrawPostBurnOrbitInfo(newRadius, orbit.Periapsis, orbit.Mu, parentRadius);
     }
 
     #endregion
@@ -185,7 +171,7 @@ static class ManeuverToolsWindow
 
         DrawTargetSelector(source);
 
-        Orbit? targetOrbit = GetSelectedTargetOrbit();
+        Orbit? targetOrbit = (_selectedTarget.Body as IOrbiter)?.Orbit;
         if (targetOrbit == null)
         {
             ImGui.Text("Select a target body."u8);
@@ -226,23 +212,79 @@ static class ManeuverToolsWindow
         TrueAnomaly dnTa = orbit.GetDescendingNode(targetOrbit);
         SimTime anTime = orbit.TimeOfTrueAnomaly(anTa, now);
         SimTime dnTime = orbit.TimeOfTrueAnomaly(dnTa, now);
-        double timeToAn = anTime.Seconds() - now.Seconds();
-        double timeToDn = dnTime.Seconds() - now.Seconds();
-
-        double speedAtAn = orbit.GetStateVectorsAt(anTime).VelocityCci.Length();
-        double speedAtDn = orbit.GetStateVectorsAt(dnTime).VelocityCci.Length();
 
         var anResult = OrbitManeuvers.ComputeMatchInclination(orbit, targetOrbit, false, now);
         var dnResult = OrbitManeuvers.ComputeMatchInclination(orbit, targetOrbit, true, now);
-        double dvAn = anResult?.DvCci.Length() ?? 0.0;
-        double dvDn = dnResult?.DvCci.Length() ?? 0.0;
+
+        DrawNodeSelection(orbit, anTime, dnTime, anResult, dnResult);
+    }
+
+    #endregion
+
+    #region Set Inclination
+
+    private static void DrawSetInclination(Vehicle source)
+    {
+        Orbit orbit = source.Orbit;
+        SimTime now = Universe.GetElapsedSimTime();
+        double currentIncDeg = orbit.Inclination * (180.0 / Math.PI);
 
         if (!_defaultsInitialized)
         {
-            // Default to whichever node costs less dV (plane changes at higher
-            // altitude are cheaper because orbital speed is lower there)
-            UseDescendingNode = dvDn < dvAn;
+            _inputInclinationDeg = currentIncDeg;
             _defaultsInitialized = true;
+        }
+
+        ImGui.Text("Target Inclination (deg):");
+        ImGui.SameLine(220f);
+        ImGui.PushItemWidth(-1f);
+        ImGui.InputDouble("##incInput"u8, ref _inputInclinationDeg, 1.0, 10.0,
+            default(ImString), ImGuiInputTextFlags.CharsDecimal);
+        _inputInclinationDeg = Math.Clamp(_inputInclinationDeg, 0.0, 180.0);
+        ImGui.PopItemWidth();
+        TargetInclinationRad = _inputInclinationDeg * (Math.PI / 180.0);
+
+        ImGui.Spacing();
+        ImGuiHelper.DrawTextWidget("Current Inclination:"u8,
+            string.Format(Inv, "{0:F2} deg", currentIncDeg));
+
+        double incDiff = Math.Abs(_inputInclinationDeg - currentIncDeg);
+        if (incDiff < 0.06)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, new ImColor8(80, 220, 80, 255));
+            ImGui.Text("Already at target inclination."u8);
+            ImGui.PopStyleColor();
+            return;
+        }
+
+        var (_, _, anTime, dnTime) = OrbitManeuvers.GetEquatorialNodes(orbit, now);
+
+        var anResult = OrbitManeuvers.ComputeSetInclination(orbit, TargetInclinationRad, false, now);
+        var dnResult = OrbitManeuvers.ComputeSetInclination(orbit, TargetInclinationRad, true, now);
+
+        DrawNodeSelection(orbit, anTime, dnTime, anResult, dnResult);
+    }
+
+    /// <summary>
+    /// Draws the AN/DN radio buttons with time, dV, and speed info.
+    /// Shared between Match Target and Set Angle modes.
+    /// </summary>
+    private static void DrawNodeSelection(Orbit orbit,
+        SimTime anTime, SimTime dnTime,
+        OrbitManeuvers.ManeuverResult? anResult, OrbitManeuvers.ManeuverResult? dnResult)
+    {
+        SimTime now = Universe.GetElapsedSimTime();
+        double timeToAn = anTime.Seconds() - now.Seconds();
+        double timeToDn = dnTime.Seconds() - now.Seconds();
+        double speedAtAn = orbit.GetStateVectorsAt(anTime).VelocityCci.Length();
+        double speedAtDn = orbit.GetStateVectorsAt(dnTime).VelocityCci.Length();
+        double dvAn = anResult?.DvCci.Length() ?? 0.0;
+        double dvDn = dnResult?.DvCci.Length() ?? 0.0;
+
+        if (!_nodeDefaultInitialized)
+        {
+            UseDescendingNode = dvDn < dvAn;
+            _nodeDefaultInitialized = true;
         }
 
         ImGui.Spacing();
@@ -251,7 +293,7 @@ static class ManeuverToolsWindow
         if (ImGui.RadioButton("Ascending Node"u8, useAn))
             UseDescendingNode = false;
         if (ImGui.IsItemHovered())
-            ImGui.SetTooltip("The point where your orbit crosses upward through the target's\norbital plane. A normal burn here aligns your orbital plane\nwith the target. Lower speed at the node means cheaper dV."u8);
+            ImGui.SetTooltip("The point where your orbit crosses upward through the reference\nplane. A normal burn here changes your orbital inclination.\nLower speed at the node means cheaper dV."u8);
         ImGui.Indent();
         ImGuiHelper.DrawTextWidget("Time to Burn:"u8, FormatTimeSpan(timeToAn));
         ImGuiHelper.DrawTextWidget("Required Delta V:"u8, string.Format(Inv, "{0:F1} m/s", dvAn));
@@ -264,7 +306,7 @@ static class ManeuverToolsWindow
         if (ImGui.RadioButton("Descending Node"u8, useDn))
             UseDescendingNode = true;
         if (ImGui.IsItemHovered())
-            ImGui.SetTooltip("The point where your orbit crosses downward through the target's\norbital plane. Same plane change as ascending node but at the\nopposite side of the orbit. May cost less dV if speed is lower here."u8);
+            ImGui.SetTooltip("The point where your orbit crosses downward through the reference\nplane. Same plane change but at the opposite side of the orbit.\nMay cost less dV if speed is lower here."u8);
         ImGui.Indent();
         ImGuiHelper.DrawTextWidget("Time to Burn:"u8, FormatTimeSpan(timeToDn));
         ImGuiHelper.DrawTextWidget("Required Delta V:"u8, string.Format(Inv, "{0:F1} m/s", dvDn));
@@ -274,7 +316,12 @@ static class ManeuverToolsWindow
 
     private static void DrawTargetSelector(Vehicle source)
     {
-        _targetList ??= BuildTargetList(source);
+        int currentCount = Universe.CurrentSystem?.All.GetList().Count ?? 0;
+        if (_targetList == null || currentCount != _lastObjectCount)
+        {
+            _targetList = BuildTargetList(source);
+            _lastObjectCount = currentCount;
+        }
 
         if (_targetList.Count == 0)
         {
@@ -322,10 +369,6 @@ static class ManeuverToolsWindow
 
     #region Post-Burn Orbit Info
 
-    /// <summary>
-    /// Shows the resulting orbital parameters after the burn.
-    /// Used by Set Pe/Ap to display new orbit characteristics.
-    /// </summary>
     private static void DrawPostBurnOrbitInfo(double apRadius, double peRadius, double mu,
         double parentRadius)
     {

--- a/AdvancedFlightComputer/Features/ManeuverTools/ManeuverToolsWindow.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/ManeuverToolsWindow.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Brutal.ImGuiApi;
+using Brutal.Numerics;
+using KSA;
+
+namespace AdvancedFlightComputer.Features.ManeuverTools;
+
+/// <summary>
+/// Type-specific UI controls for maneuver quick-tools. Drawn inline within the
+/// Transfer Planning window by DrawPlanWindowPatch.
+///
+/// - Set Periapsis / Set Apoapsis: altitude input, current orbit info, post-burn orbit
+/// - Match Inclination: target dropdown, Set Target, AN/DN radio buttons with tooltips
+///
+/// Static state (TargetAltitude, UseDescendingNode) is read by DrawPlanWindowPatch
+/// to compute the maneuver in the same frame.
+/// </summary>
+static class ManeuverToolsWindow
+{
+    private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+
+    #region Shared State (read by DrawPlanWindowPatch)
+
+    public static double TargetAltitude;
+    public static bool UseDescendingNode;
+
+    #endregion
+
+    #region Internal State
+
+    private static double _inputAltitudeKm;
+    private static bool _defaultsInitialized;
+    private static string? _lastSourceId;
+
+    private static TransferObject _selectedTarget;
+    private static List<TransferObject>? _targetList;
+    private static bool _setTarget;
+
+    #endregion
+
+    public static void DrawInline(string typeKey, Vehicle source)
+    {
+        if (_lastSourceId != source.Id)
+        {
+            _lastSourceId = source.Id;
+            _defaultsInitialized = false;
+            _targetList = null;
+        }
+
+        if (typeKey == ManeuverTools.KeySetPeriapsis)
+            DrawSetPeriapsis(source);
+        else if (typeKey == ManeuverTools.KeySetApoapsis)
+            DrawSetApoapsis(source);
+        else if (typeKey == ManeuverTools.KeyMatchInclination)
+            DrawMatchInclination(source);
+    }
+
+    public static Orbit? GetSelectedTargetOrbit()
+    {
+        return (_selectedTarget.Body as IOrbiter)?.Orbit;
+    }
+
+    public static void OnTypeChanged()
+    {
+        _defaultsInitialized = false;
+        _targetList = null;
+    }
+
+    public static void OnSourceChanged()
+    {
+        _defaultsInitialized = false;
+        _targetList = null;
+    }
+
+    public static void Reset()
+    {
+        TargetAltitude = 0.0;
+        UseDescendingNode = false;
+        _inputAltitudeKm = 0.0;
+        _defaultsInitialized = false;
+        _lastSourceId = null;
+        _selectedTarget = default;
+        _targetList = null;
+        _setTarget = false;
+    }
+
+    #region Set Periapsis
+
+    private static void DrawSetPeriapsis(Vehicle source)
+    {
+        Orbit orbit = source.Orbit;
+        double parentRadius = source.Parent?.MeanRadius ?? 0.0;
+        double currentPeAlt = Math.Max(0.0, orbit.Periapsis - parentRadius);
+        double currentApAlt = Math.Max(0.0, orbit.Apoapsis - parentRadius);
+
+        if (!_defaultsInitialized)
+        {
+            _inputAltitudeKm = currentPeAlt / 1000.0;
+            _defaultsInitialized = true;
+        }
+
+        if (orbit.Eccentricity >= 1.0)
+        {
+            ImGui.Text("Requires a bound (elliptical) orbit."u8);
+            return;
+        }
+
+        DrawAltitudeInput("Target Periapsis (km):");
+        TargetAltitude = _inputAltitudeKm * 1000.0;
+
+        ImGui.Spacing();
+        ImGuiHelper.DrawTextWidget("Current Periapsis:"u8, FormatDistance(currentPeAlt));
+        ImGuiHelper.DrawTextWidget("Current Apoapsis:"u8, FormatDistance(currentApAlt));
+        ImGuiHelper.DrawTextWidget("Burn Location:"u8, "Apoapsis");
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Burns at apoapsis change the periapsis on the opposite\nside of the orbit. This is the most fuel-efficient point\nto lower or raise your periapsis."u8);
+
+        if (_inputAltitudeKm >= currentApAlt / 1000.0 - 1.0)
+        {
+            ImGui.Spacing();
+            ImGui.PushStyleColor(ImGuiCol.Text, new ImColor8(255, 200, 60, 255));
+            ImGui.Text("Target must be below current apoapsis."u8);
+            ImGui.PopStyleColor();
+            return;
+        }
+
+        DrawPostBurnOrbitInfo(orbit.Apoapsis, TargetAltitude + parentRadius, orbit.Mu, parentRadius);
+    }
+
+    #endregion
+
+    #region Set Apoapsis
+
+    private static void DrawSetApoapsis(Vehicle source)
+    {
+        Orbit orbit = source.Orbit;
+        double parentRadius = source.Parent?.MeanRadius ?? 0.0;
+        double currentPeAlt = Math.Max(0.0, orbit.Periapsis - parentRadius);
+        double currentApAlt = Math.Max(0.0, orbit.Apoapsis - parentRadius);
+
+        if (!_defaultsInitialized)
+        {
+            _inputAltitudeKm = currentApAlt / 1000.0;
+            _defaultsInitialized = true;
+        }
+
+        if (orbit.Eccentricity >= 1.0)
+        {
+            ImGui.Text("Requires a bound (elliptical) orbit."u8);
+            return;
+        }
+
+        DrawAltitudeInput("Target Apoapsis (km):");
+        TargetAltitude = _inputAltitudeKm * 1000.0;
+
+        ImGui.Spacing();
+        ImGuiHelper.DrawTextWidget("Current Periapsis:"u8, FormatDistance(currentPeAlt));
+        ImGuiHelper.DrawTextWidget("Current Apoapsis:"u8, FormatDistance(currentApAlt));
+        ImGuiHelper.DrawTextWidget("Burn Location:"u8, "Periapsis");
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Burns at periapsis change the apoapsis on the opposite\nside of the orbit. This is the most fuel-efficient point\nto lower or raise your apoapsis."u8);
+
+        if (_inputAltitudeKm <= currentPeAlt / 1000.0 + 1.0)
+        {
+            ImGui.Spacing();
+            ImGui.PushStyleColor(ImGuiCol.Text, new ImColor8(255, 200, 60, 255));
+            ImGui.Text("Target must be above current periapsis."u8);
+            ImGui.PopStyleColor();
+            return;
+        }
+
+        DrawPostBurnOrbitInfo(TargetAltitude + parentRadius, orbit.Periapsis, orbit.Mu, parentRadius);
+    }
+
+    #endregion
+
+    #region Match Inclination
+
+    private static void DrawMatchInclination(Vehicle source)
+    {
+        Orbit orbit = source.Orbit;
+        SimTime now = Universe.GetElapsedSimTime();
+
+        DrawTargetSelector(source);
+
+        Orbit? targetOrbit = GetSelectedTargetOrbit();
+        if (targetOrbit == null)
+        {
+            ImGui.Text("Select a target body."u8);
+            return;
+        }
+
+        IOrbiter? targetOrbiter = _selectedTarget.Body as IOrbiter;
+
+        ImGui.Spacing();
+        ImGuiHelper.BeginColumns(2, new float[] { 0.9f });
+        bool prevSetTarget = _setTarget;
+        if (ImGuiHelper.DrawCheckbox("Set Target"u8, ref _setTarget, isChanged: false))
+        {
+            if (_setTarget != prevSetTarget)
+            {
+                if (_setTarget && targetOrbiter != null)
+                    Universe.SetTarget(source, targetOrbiter);
+                else
+                    Universe.UnsetTarget(source);
+            }
+        }
+        ImGuiHelper.EndColumns();
+
+        double relIncDeg = orbit.GetRelativeInclination(targetOrbit).Value() * (180.0 / Math.PI);
+        ImGui.Spacing();
+        ImGuiHelper.DrawTextWidget("Relative Inclination:"u8,
+            string.Format(Inv, "{0:F2} deg", relIncDeg));
+
+        if (relIncDeg < 0.06)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, new ImColor8(80, 220, 80, 255));
+            ImGui.Text("Orbits are already nearly coplanar."u8);
+            ImGui.PopStyleColor();
+            return;
+        }
+
+        TrueAnomaly anTa = orbit.GetAscendingNode(targetOrbit);
+        TrueAnomaly dnTa = orbit.GetDescendingNode(targetOrbit);
+        SimTime anTime = orbit.TimeOfTrueAnomaly(anTa, now);
+        SimTime dnTime = orbit.TimeOfTrueAnomaly(dnTa, now);
+        double timeToAn = anTime.Seconds() - now.Seconds();
+        double timeToDn = dnTime.Seconds() - now.Seconds();
+
+        double speedAtAn = orbit.GetStateVectorsAt(anTime).VelocityCci.Length();
+        double speedAtDn = orbit.GetStateVectorsAt(dnTime).VelocityCci.Length();
+
+        var anResult = OrbitManeuvers.ComputeMatchInclination(orbit, targetOrbit, false, now);
+        var dnResult = OrbitManeuvers.ComputeMatchInclination(orbit, targetOrbit, true, now);
+        double dvAn = anResult?.DvCci.Length() ?? 0.0;
+        double dvDn = dnResult?.DvCci.Length() ?? 0.0;
+
+        if (!_defaultsInitialized)
+        {
+            // Default to whichever node costs less dV (plane changes at higher
+            // altitude are cheaper because orbital speed is lower there)
+            UseDescendingNode = dvDn < dvAn;
+            _defaultsInitialized = true;
+        }
+
+        ImGui.Spacing();
+
+        bool useAn = !UseDescendingNode;
+        if (ImGui.RadioButton("Ascending Node"u8, useAn))
+            UseDescendingNode = false;
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("The point where your orbit crosses upward through the target's\norbital plane. A normal burn here aligns your orbital plane\nwith the target. Lower speed at the node means cheaper dV."u8);
+        ImGui.Indent();
+        ImGuiHelper.DrawTextWidget("Time to Burn:"u8, FormatTimeSpan(timeToAn));
+        ImGuiHelper.DrawTextWidget("Required Delta V:"u8, string.Format(Inv, "{0:F1} m/s", dvAn));
+        ImGuiHelper.DrawTextWidget("Speed at Node:"u8, string.Format(Inv, "{0:F1} m/s", speedAtAn));
+        ImGui.Unindent();
+
+        ImGui.Spacing();
+
+        bool useDn = UseDescendingNode;
+        if (ImGui.RadioButton("Descending Node"u8, useDn))
+            UseDescendingNode = true;
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("The point where your orbit crosses downward through the target's\norbital plane. Same plane change as ascending node but at the\nopposite side of the orbit. May cost less dV if speed is lower here."u8);
+        ImGui.Indent();
+        ImGuiHelper.DrawTextWidget("Time to Burn:"u8, FormatTimeSpan(timeToDn));
+        ImGuiHelper.DrawTextWidget("Required Delta V:"u8, string.Format(Inv, "{0:F1} m/s", dvDn));
+        ImGuiHelper.DrawTextWidget("Speed at Node:"u8, string.Format(Inv, "{0:F1} m/s", speedAtDn));
+        ImGui.Unindent();
+    }
+
+    private static void DrawTargetSelector(Vehicle source)
+    {
+        _targetList ??= BuildTargetList(source);
+
+        if (_targetList.Count == 0)
+        {
+            ImGui.Text("No targets available in current SOI."u8);
+            return;
+        }
+
+        if (_selectedTarget.GetKey() == "N/A" && _targetList.Count > 0)
+            _selectedTarget = _targetList[0];
+
+        TransferObject prevTarget = _selectedTarget;
+        if (ImGuiHelper.DrawCombo("Target:"u8, ref _selectedTarget, _targetList)
+            && _selectedTarget.GetKey() != prevTarget.GetKey())
+        {
+            _defaultsInitialized = false;
+            if (_setTarget && _selectedTarget.Body is IOrbiter newOrbiter)
+                Universe.SetTarget(source, newOrbiter);
+        }
+    }
+
+    private static List<TransferObject> BuildTargetList(Vehicle source)
+    {
+        var list = new List<TransferObject>();
+        IParentBody? parent = source.Parent;
+        if (parent == null || Universe.CurrentSystem == null)
+            return list;
+
+        foreach (Astronomical astro in Universe.CurrentSystem.All.GetList())
+        {
+            if (astro == source) continue;
+            if (astro is StellarBody) continue;
+            if ((astro as IOrbiter)?.Orbit == null) continue;
+
+            if ((astro is Celestial celestial && celestial.Parent?.Id == parent.Id)
+                || (astro is Vehicle vehicle && vehicle.Parent?.Id == parent.Id))
+            {
+                list.Add(new TransferObject(astro));
+            }
+        }
+
+        return list;
+    }
+
+    #endregion
+
+    #region Post-Burn Orbit Info
+
+    /// <summary>
+    /// Shows the resulting orbital parameters after the burn.
+    /// Used by Set Pe/Ap to display new orbit characteristics.
+    /// </summary>
+    private static void DrawPostBurnOrbitInfo(double apRadius, double peRadius, double mu,
+        double parentRadius)
+    {
+        double sma = (apRadius + peRadius) / 2.0;
+        if (sma <= 0.0) return;
+
+        double ecc = (apRadius - peRadius) / (apRadius + peRadius);
+        double period = 2.0 * Math.PI * Math.Sqrt(sma * sma * sma / mu);
+
+        ImGui.Spacing();
+        ImGui.PushStyleColor(ImGuiCol.Text, ImGui.GetStyleColorVec4(ImGuiCol.TextDisabled));
+        ImGui.Text("Resulting Orbit:"u8);
+        ImGuiHelper.DrawTextWidget("  Periapsis:"u8, FormatDistance(peRadius - parentRadius));
+        ImGuiHelper.DrawTextWidget("  Apoapsis:"u8, FormatDistance(apRadius - parentRadius));
+        ImGuiHelper.DrawTextWidget("  Eccentricity:"u8, string.Format(Inv, "{0:F4}", ecc));
+        ImGuiHelper.DrawTextWidget("  Period:"u8, FormatTimeSpan(period));
+        ImGui.PopStyleColor();
+    }
+
+    #endregion
+
+    #region UI Helpers
+
+    private static void DrawAltitudeInput(string label)
+    {
+        ImGui.Text(label);
+        ImGui.SameLine(220f);
+        ImGui.PushItemWidth(-1f);
+        ImGui.InputDouble("##altInput"u8, ref _inputAltitudeKm, 10.0, 100.0,
+            default(ImString), ImGuiInputTextFlags.CharsDecimal);
+        if (_inputAltitudeKm < 0.0)
+            _inputAltitudeKm = 0.0;
+        ImGui.PopItemWidth();
+    }
+
+    #endregion
+
+    #region Formatting
+
+    internal static string FormatDistance(double meters)
+    {
+        if (double.IsNaN(meters) || double.IsInfinity(meters))
+            return "N/A";
+        if (meters >= 1e9)
+            return string.Format(Inv, "{0:F1} Gm", meters / 1e9);
+        if (meters >= 1e6)
+            return string.Format(Inv, "{0:F1} Mm", meters / 1e6);
+        if (meters >= 1000.0)
+            return string.Format(Inv, "{0:F1} km", meters / 1000.0);
+        return string.Format(Inv, "{0:F0} m", meters);
+    }
+
+    internal static string FormatTimeSpan(double seconds)
+    {
+        if (double.IsNaN(seconds) || double.IsInfinity(seconds))
+            return "N/A";
+        if (seconds < 0)
+            return "past";
+        if (seconds < 60.0)
+            return string.Format(Inv, "{0:F0}s", seconds);
+        if (seconds < 3600.0)
+        {
+            int m = (int)(seconds / 60.0);
+            int s = (int)(seconds % 60.0);
+            return s > 0 ? $"{m}m {s}s" : $"{m}m";
+        }
+        if (seconds < 86400.0)
+        {
+            int h = (int)(seconds / 3600.0);
+            int min = (int)((seconds % 3600.0) / 60.0);
+            return min > 0 ? $"{h}h {min}m" : $"{h}h";
+        }
+        int d = (int)(seconds / 86400.0);
+        int hr = (int)((seconds % 86400.0) / 3600.0);
+        return hr > 0 ? $"{d}d {hr}h" : $"{d}d";
+    }
+
+    #endregion
+}

--- a/AdvancedFlightComputer/Features/ManeuverTools/OrbitManeuvers.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/OrbitManeuvers.cs
@@ -1,0 +1,157 @@
+using System;
+using Brutal.Numerics;
+using KSA;
+
+namespace AdvancedFlightComputer.Features.ManeuverTools;
+
+/// <summary>
+/// Pure dV calculations for maneuver planning. All methods are stateless
+/// and return nullable results to signal invalid inputs (e.g. hyperbolic
+/// orbit for apse maneuvers, coplanar orbits for inclination matching).
+/// </summary>
+static class OrbitManeuvers
+{
+    public record struct ManeuverResult(double3 DvCci, double3 DvVlf, SimTime BurnTime);
+
+    /// <summary>
+    /// Computes a prograde/retrograde burn at the next apoapsis to set periapsis
+    /// to a target altitude above the parent body's surface.
+    /// </summary>
+    public static ManeuverResult? ComputeSetPeriapsis(
+        Orbit orbit, double targetAltitudeMeters, double parentRadius, SimTime now)
+    {
+        if (orbit.Eccentricity >= 1.0)
+            return null;
+
+        double currentApRadius = orbit.Apoapsis;
+        double newPeRadius = targetAltitudeMeters + parentRadius;
+
+        if (newPeRadius <= 0.0 || newPeRadius >= currentApRadius)
+            return null;
+
+        SimTime burnTime = orbit.GetNextApoapsisTime(now);
+        return ComputeApseBurn(orbit, burnTime, currentApRadius, newPeRadius);
+    }
+
+    /// <summary>
+    /// Computes a prograde/retrograde burn at the next periapsis to set apoapsis
+    /// to a target altitude above the parent body's surface.
+    /// </summary>
+    public static ManeuverResult? ComputeSetApoapsis(
+        Orbit orbit, double targetAltitudeMeters, double parentRadius, SimTime now)
+    {
+        if (orbit.Eccentricity >= 1.0)
+            return null;
+
+        double currentPeRadius = orbit.Periapsis;
+        double newApRadius = targetAltitudeMeters + parentRadius;
+
+        if (newApRadius <= currentPeRadius)
+            return null;
+
+        SimTime burnTime = orbit.GetNextPeriapsisTime(now);
+        return ComputeApseBurn(orbit, burnTime, currentPeRadius, newApRadius);
+    }
+
+    /// <summary>
+    /// Computes a plane-change burn at the ascending or descending node to match
+    /// a target orbit's inclination. Preserves orbital speed, only rotates the
+    /// velocity vector into the target's orbital plane.
+    /// </summary>
+    public static ManeuverResult? ComputeMatchInclination(
+        Orbit vehicleOrbit, Orbit targetOrbit, bool useDescendingNode, SimTime now)
+    {
+        double relInc = vehicleOrbit.GetRelativeInclination(targetOrbit).Value();
+        if (relInc < 0.001)
+            return null;
+
+        TrueAnomaly nodeTa = useDescendingNode
+            ? vehicleOrbit.GetDescendingNode(targetOrbit)
+            : vehicleOrbit.GetAscendingNode(targetOrbit);
+
+        if (nodeTa == TrueAnomaly.NaN)
+            return null;
+
+        SimTime nodeTime = vehicleOrbit.TimeOfTrueAnomaly(nodeTa, now);
+        StateVectors sv = vehicleOrbit.GetStateVectorsAt(nodeTime);
+
+        double3 vehicleNormal = vehicleOrbit.GetOrbitNormalCci();
+        double3 targetNormal = targetOrbit.GetOrbitNormalCci();
+        double3 rotAxis = double3.Cross(vehicleNormal, targetNormal).NormalizeOrZero();
+
+        if (rotAxis.LengthSquared() < 1e-12)
+            return null;
+
+        doubleQuat planeChange = QuaternionEx.AngleAxis(relInc, rotAxis);
+        double3 targetVel = sv.VelocityCci.Transform(planeChange);
+        double3 dvCci = targetVel - sv.VelocityCci;
+
+        double3 dvVlf = CciToVlf(dvCci, vehicleOrbit, nodeTime);
+        return new ManeuverResult(dvCci, dvVlf, nodeTime);
+    }
+
+    /// <summary>
+    /// Builds a PorkChopEntry + TransferInfo for use with the stock Create button.
+    /// Follows the exact same pattern as stock Circularize (TransferPlanner.cs:389-412).
+    /// </summary>
+    public static (OrbitalTransfers.PorkChopEntry entry, OrbitalTransfers.TransferInfo info)
+        BuildTransferEntry(Vehicle source, ManeuverResult maneuver)
+    {
+        var transferData = new OrbitalTransfers.TransferData
+        {
+            Start = maneuver.BurnTime,
+            Point = source.Orbit.GetPointAt(maneuver.BurnTime),
+            DeltaVelocityCci = maneuver.DvCci,
+            TransferDvVlf = maneuver.DvVlf
+        };
+
+        var info = new OrbitalTransfers.TransferInfo(source, source, source, usePorkChopData: false);
+        info.PorkChopData = new OrbitalTransfers.PorkChopEntry[1, 1];
+
+        FlightPlan flightPlan = FlightPlan.CreateUninitialized(source.Hash);
+        OrbitalTransfers.BuildFlightPlan(
+            ref flightPlan, info, transferData.Start, transferData.TransferDvVlf,
+            out _, out _);
+
+        var entry = new OrbitalTransfers.PorkChopEntry(transferData, flightPlan);
+        info.PorkChopData[0, 0] = entry;
+
+        return (entry, info);
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Generic apse burn: given the burn radius and the opposite apse radius,
+    /// compute the dV needed to create an orbit passing through both.
+    /// </summary>
+    private static ManeuverResult? ComputeApseBurn(
+        Orbit orbit, SimTime burnTime, double burnRadius, double oppositeRadius)
+    {
+        StateVectors sv = orbit.GetStateVectorsAt(burnTime);
+        double r = sv.PositionCci.Length();
+        double newSma = (burnRadius + oppositeRadius) / 2.0;
+
+        if (newSma <= 0.0)
+            return null;
+
+        double vNew = Math.Sqrt(orbit.Mu * (2.0 / r - 1.0 / newSma));
+        double3 vDir = sv.VelocityCci.NormalizeOrZero();
+        double3 dvCci = vDir * vNew - sv.VelocityCci;
+
+        double3 dvVlf = CciToVlf(dvCci, orbit, burnTime);
+        return new ManeuverResult(dvCci, dvVlf, burnTime);
+    }
+
+    /// <summary>
+    /// Converts a dV vector from CCI frame to VLF frame, using the same
+    /// transformation as stock Circularize (TransferPlanner.cs:394-396).
+    /// </summary>
+    private static double3 CciToVlf(double3 dvCci, Orbit orbit, SimTime time)
+    {
+        doubleQuat vlf2Cci = orbit.GetStateVectorsAt(time).GetVlf2ParentCci().OrIdentity();
+        return dvCci.Transform(vlf2Cci.Inverse());
+    }
+
+    #endregion
+}

--- a/AdvancedFlightComputer/Features/ManeuverTools/OrbitManeuvers.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/OrbitManeuvers.cs
@@ -119,6 +119,79 @@ static class OrbitManeuvers
         return (entry, info);
     }
 
+    /// <summary>
+    /// Computes a plane-change burn at the ascending or descending node (relative
+    /// to the parent body's equatorial plane) to set the orbit's inclination to
+    /// a specific angle. Preserves orbital speed and LAN.
+    /// </summary>
+    public static ManeuverResult? ComputeSetInclination(
+        Orbit orbit, double targetInclinationRad, bool useDescendingNode, SimTime now)
+    {
+        targetInclinationRad = Math.Clamp(targetInclinationRad, 0.0, Math.PI);
+
+        double currentInc = orbit.Inclination;
+        double incDiff = Math.Abs(targetInclinationRad - currentInc);
+        if (incDiff < 0.001)
+            return null;
+
+        double3 vehicleNormal = orbit.GetOrbitNormalCci();
+        double3 equatorialNormal = new double3(0, 0, 1);
+
+        // AN/DN relative to equatorial plane
+        double3 nodeDir = double3.Cross(equatorialNormal, vehicleNormal).NormalizeOrZero();
+        if (nodeDir.LengthSquared() < 1e-12)
+            nodeDir = new double3(1, 0, 0); // fallback for equatorial orbits
+
+        TrueAnomaly anTa = orbit.GetTrueAnomaly(nodeDir);
+        TrueAnomaly nodeTa = useDescendingNode
+            ? new TrueAnomaly((anTa.Value() + Math.PI) % (Math.PI * 2.0))
+            : anTa;
+
+        SimTime nodeTime = orbit.TimeOfTrueAnomaly(nodeTa, now);
+        StateVectors sv = orbit.GetStateVectorsAt(nodeTime);
+
+        // Target normal: same LAN, new inclination
+        double lan = orbit.LongitudeOfAscendingNode;
+        double3 targetNormal = new double3(
+            Math.Sin(targetInclinationRad) * Math.Sin(lan),
+            -Math.Sin(targetInclinationRad) * Math.Cos(lan),
+            Math.Cos(targetInclinationRad));
+
+        double3 rotAxis = double3.Cross(vehicleNormal, targetNormal).NormalizeOrZero();
+        if (rotAxis.LengthSquared() < 1e-12)
+            return null;
+
+        double rotAngle = MathEx.Angle(vehicleNormal, targetNormal).Value();
+        doubleQuat planeChange = QuaternionEx.AngleAxis(rotAngle, rotAxis);
+        double3 targetVel = sv.VelocityCci.Transform(planeChange);
+        double3 dvCci = targetVel - sv.VelocityCci;
+
+        double3 dvVlf = CciToVlf(dvCci, orbit, nodeTime);
+        return new ManeuverResult(dvCci, dvVlf, nodeTime);
+    }
+
+    /// <summary>
+    /// Computes AN/DN true anomalies and times relative to the equatorial plane.
+    /// Used by the UI to display both node options for Set Inclination.
+    /// </summary>
+    public static (TrueAnomaly anTa, TrueAnomaly dnTa, SimTime anTime, SimTime dnTime)
+        GetEquatorialNodes(Orbit orbit, SimTime now)
+    {
+        double3 vehicleNormal = orbit.GetOrbitNormalCci();
+        double3 equatorialNormal = new double3(0, 0, 1);
+        double3 nodeDir = double3.Cross(equatorialNormal, vehicleNormal).NormalizeOrZero();
+
+        if (nodeDir.LengthSquared() < 1e-12)
+            nodeDir = new double3(1, 0, 0);
+
+        TrueAnomaly anTa = orbit.GetTrueAnomaly(nodeDir);
+        TrueAnomaly dnTa = new TrueAnomaly((anTa.Value() + Math.PI) % (Math.PI * 2.0));
+        SimTime anTime = orbit.TimeOfTrueAnomaly(anTa, now);
+        SimTime dnTime = orbit.TimeOfTrueAnomaly(dnTa, now);
+
+        return (anTa, dnTa, anTime, dnTime);
+    }
+
     #region Helpers
 
     /// <summary>

--- a/AdvancedFlightComputer/Mod.cs
+++ b/AdvancedFlightComputer/Mod.cs
@@ -1,6 +1,7 @@
 using AdvancedFlightComputer.Core;
 using AdvancedFlightComputer.Features.AutoStage;
 using AdvancedFlightComputer.Features.HyperbolicTargets;
+using AdvancedFlightComputer.Features.ManeuverTools;
 using AdvancedFlightComputer.Features.StageInfo;
 using Brutal.Logging;
 using HarmonyLib;
@@ -59,6 +60,14 @@ public class Mod
         else
             DefaultCategory.Log.Warning("[AFC] StageInfo disabled - reflection targets not found.");
 
+        if (GameReflection.ValidateManeuverTools())
+        {
+            ManeuverTools.InjectTransferTypes();
+            ManeuverTools.ApplyPatches(_harmony);
+        }
+        else
+            DefaultCategory.Log.Warning("[AFC] ManeuverTools disabled - reflection targets not found.");
+
         DefaultCategory.Log.Info("[AFC] Loaded and patched.");
     }
 
@@ -74,6 +83,8 @@ public class Mod
         StageInfoSettings.Reset();
         CorrectedBurnState.Clear();
         StageAnalyzer.ResetPools();
+        ManeuverToolsWindow.Reset();
+        Patch_DrawPlanWindow.Reset();
         LogHelper.Reset();
 #if DEBUG
         PerfTracker.Reset();


### PR DESCRIPTION
## Summary

- Adds 4 new plan types to the stock Transfer Planner dropdown: **Set Periapsis**, **Set Apoapsis**, **Match Inclination**, **Set Inclination**
- Each computes a single burn via vis-viva or plane-change math and creates a standard maneuver node
- Integrates seamlessly into the stock Transfer Planning window (Prefix on `DrawPlanWindow` that takes over for AFC types)

## Features

- **Set Periapsis / Set Apoapsis**: Altitude input in km, burn at opposite apse, post-burn orbit info (Pe/Ap/eccentricity/period), tooltips explaining burn location
- **Match Inclination**: Target dropdown with all SOI objects (celestials + vehicles), Set Target checkbox, AN/DN selection with time/dV/speed display, auto-selects cheapest node
- **Set Inclination**: Arbitrary inclination angle input, burns at equatorial plane nodes, preserves LAN, edge case handling for equatorial orbits
- **Visual orbit preview**: Post-burn orbit rendered in 3D view via `FlightPlan.AddLineInstances` (Postfix on `OnPreRender`)
- **Flight plan preview**: Patch details window (same as stock Hohmann)