### PR TITLE
Add orbit preview markers, extract FormatDuration, cache vehicle list

### DIFF
--- a/AdvancedFlightComputer/Core/FormatHelper.cs
+++ b/AdvancedFlightComputer/Core/FormatHelper.cs
@@ -1,0 +1,34 @@
+namespace AdvancedFlightComputer.Core;
+
+static class FormatHelper
+{
+    /// <summary>
+    /// Formats a duration in seconds as a human-readable string.
+    /// Returns "past" for negative values, "N/A" for NaN/Infinity.
+    /// Uses the largest appropriate unit: seconds, minutes, hours, days.
+    /// </summary>
+    public static string FormatDuration(double seconds)
+    {
+        if (double.IsNaN(seconds) || double.IsInfinity(seconds))
+            return "N/A";
+        if (seconds < 0)
+            return "past";
+        if (seconds < 60.0)
+            return $"{seconds:F0}s";
+        if (seconds < 3600.0)
+        {
+            int m = (int)(seconds / 60.0);
+            int s = (int)(seconds % 60.0);
+            return s > 0 ? $"{m}m {s}s" : $"{m}m";
+        }
+        if (seconds < 86400.0)
+        {
+            int h = (int)(seconds / 3600.0);
+            int min = (int)((seconds % 3600.0) / 60.0);
+            return min > 0 ? $"{h}h {min}m" : $"{h}h";
+        }
+        int d = (int)(seconds / 86400.0);
+        int hr = (int)((seconds % 86400.0) / 3600.0);
+        return hr > 0 ? $"{d}d {hr}h" : $"{d}d";
+    }
+}

--- a/AdvancedFlightComputer/Features/ManeuverTools/DrawPlanWindowPatch.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/DrawPlanWindowPatch.cs
@@ -30,6 +30,9 @@ static class Patch_DrawPlanWindow
     private static bool _showFlightPlanPreview;
     private static bool _showOrbitPreview;
 
+    private static List<TransferObject>? _vehicleList;
+    private static int _lastVehicleCount;
+
     static bool Prefix(Viewport inViewport)
     {
         try
@@ -128,6 +131,9 @@ static class Patch_DrawPlanWindow
 
         ImGui.End();
 
+        if (_showOrbitPreview && _lastEntry != null && _lastSource != null)
+            DrawOrbitMarkers(inViewport);
+
         if (_showFlightPlanPreview && _lastEntry != null)
             DrawFlightPlanWindow(inViewport);
     }
@@ -156,9 +162,15 @@ static class Patch_DrawPlanWindow
     private static Vehicle? DrawSourceDropdown()
     {
         var sourceBody = (TransferObject)GameReflection.TransferPlanner_sourceBody!.GetValue(null)!;
-        var vehicleList = new List<TransferObject>();
-        foreach (Vehicle v in Universe.CurrentSystem!.Vehicles.GetList())
-            vehicleList.Add(new TransferObject(v));
+        int currentCount = Universe.CurrentSystem!.Vehicles.GetList().Count;
+        if (_vehicleList == null || currentCount != _lastVehicleCount)
+        {
+            _vehicleList = new List<TransferObject>();
+            foreach (Vehicle v in Universe.CurrentSystem.Vehicles.GetList())
+                _vehicleList.Add(new TransferObject(v));
+            _lastVehicleCount = currentCount;
+        }
+        var vehicleList = _vehicleList;
 
         if (ImGui.IsWindowAppearing() || sourceBody.GetKey() == "N/A")
         {
@@ -258,6 +270,20 @@ static class Patch_DrawPlanWindow
     #region Visual Orbit Preview
 
     /// <summary>
+    /// Renders encounter, escape, impact, closest approach, and Ap/Pe markers
+    /// on the preview orbit. Called from the ImGui pass (after the main window)
+    /// using the background draw list.
+    /// </summary>
+    private static void DrawOrbitMarkers(Viewport inViewport)
+    {
+        var uiContext = new Astronomical.UiContext(
+            inViewport, _lastSource!, Color.Green,
+            TrueAnomaly.Zero, new TrueAnomaly(Math.PI * 2.0),
+            ManeuverToolsWindow.GetSelectedTargetOrbiter());
+        _lastEntry!.FlightPlan.DrawUi(inViewport, uiContext);
+    }
+
+    /// <summary>
     /// Renders the post-burn orbit in the 3D view. Called from
     /// Patch_OnPreRender when our type is active and preview is enabled.
     /// Follows the same pattern as stock DrawSelectedTransfer.
@@ -351,6 +377,8 @@ static class Patch_DrawPlanWindow
         _lastSource = null;
         _showFlightPlanPreview = false;
         _showOrbitPreview = false;
+        _vehicleList = null;
+        _lastVehicleCount = 0;
     }
 
     #endregion

--- a/AdvancedFlightComputer/Features/ManeuverTools/ManeuverToolsWindow.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/ManeuverToolsWindow.cs
@@ -69,6 +69,11 @@ static class ManeuverToolsWindow
         return (_selectedTarget.Body as IOrbiter)?.Orbit;
     }
 
+    public static IOrbiter? GetSelectedTargetOrbiter()
+    {
+        return _selectedTarget.Body as IOrbiter;
+    }
+
     public static void OnTypeChanged()
     {
         _defaultsInitialized = false;
@@ -422,29 +427,7 @@ static class ManeuverToolsWindow
     }
 
     internal static string FormatTimeSpan(double seconds)
-    {
-        if (double.IsNaN(seconds) || double.IsInfinity(seconds))
-            return "N/A";
-        if (seconds < 0)
-            return "past";
-        if (seconds < 60.0)
-            return string.Format(Inv, "{0:F0}s", seconds);
-        if (seconds < 3600.0)
-        {
-            int m = (int)(seconds / 60.0);
-            int s = (int)(seconds % 60.0);
-            return s > 0 ? $"{m}m {s}s" : $"{m}m";
-        }
-        if (seconds < 86400.0)
-        {
-            int h = (int)(seconds / 3600.0);
-            int min = (int)((seconds % 3600.0) / 60.0);
-            return min > 0 ? $"{h}h {min}m" : $"{h}h";
-        }
-        int d = (int)(seconds / 86400.0);
-        int hr = (int)((seconds % 86400.0) / 3600.0);
-        return hr > 0 ? $"{d}d {hr}h" : $"{d}d";
-    }
+        => Core.FormatHelper.FormatDuration(seconds);
 
     #endregion
 }

--- a/AdvancedFlightComputer/Features/StageInfo/StageInfoPanel.cs
+++ b/AdvancedFlightComputer/Features/StageInfo/StageInfoPanel.cs
@@ -510,19 +510,7 @@ static class StageInfoPanel
     #region Formatting
 
     private static string FormatBurnTime(float seconds)
-    {
-        if (seconds < 60f)
-            return $"{seconds:F0}s";
-        if (seconds < 3600f)
-        {
-            int m = (int)(seconds / 60f);
-            int s = (int)(seconds % 60f);
-            return s > 0 ? $"{m}m {s}s" : $"{m}m";
-        }
-        int h = (int)(seconds / 3600f);
-        int min = (int)((seconds % 3600f) / 60f);
-        return min > 0 ? $"{h}h {min}m" : $"{h}h";
-    }
+        => Core.FormatHelper.FormatDuration(seconds);
 
     #endregion
 }


### PR DESCRIPTION
- Add FlightPlan.DrawUi() call to render encounter, escape, impact, closest approach, and Ap/Pe markers on the preview orbit. Previously only orbit lines were rendered but no ImGui markers.
- Extract shared FormatHelper.FormatDuration() to eliminate duplicate FormatBurnTime/FormatTimeSpan implementations.
- Cache vehicle list in DrawSourceDropdown to avoid per-frame allocation.