### PR TITLE
Update HyperbolicTargets for KSA v2026.4.16.4170

### DIFF
--- a/AdvancedFlightComputer/Features/HyperbolicTargets/HyperbolicTargets.cs
+++ b/AdvancedFlightComputer/Features/HyperbolicTargets/HyperbolicTargets.cs
@@ -29,7 +29,7 @@ static class HyperbolicTargets
     /// </summary>
     public static void ApplyPatches(Harmony harmony)
     {
-        harmony.CreateClassProcessor(typeof(Patch_GetPlanetList)).Patch();
+        harmony.CreateClassProcessor(typeof(Patch_PopulateWithPlanets)).Patch();
         harmony.CreateClassProcessor(typeof(Patch_HohmannFlight)).Patch();
         harmony.CreateClassProcessor(typeof(Patch_SetTransferInfo)).Patch();
         harmony.CreateClassProcessor(typeof(Patch_AlignmentTime)).Patch();

--- a/AdvancedFlightComputer/Features/HyperbolicTargets/TransferPlannerPatches.cs
+++ b/AdvancedFlightComputer/Features/HyperbolicTargets/TransferPlannerPatches.cs
@@ -8,13 +8,15 @@ using KSA;
 namespace AdvancedFlightComputer.Features.HyperbolicTargets;
 
 /// <summary>
-/// The original GetPlanetList filters out eccentricity >= 1. We let it
-/// run for bound bodies, then append hyperbolic ones it skipped.
+/// PopulateWithPlanets filters out eccentricity >= 1. We let the stock logic
+/// run, then append hyperbolic bodies into the span.
 /// </summary>
-[HarmonyPatch(typeof(TransferPlanner), nameof(TransferPlanner.GetPlanetList))]
-static class Patch_GetPlanetList
+[HarmonyPatch(typeof(TransferPlanner), nameof(TransferPlanner.PopulateWithPlanets),
+    new Type[] { typeof(Span<TransferObject>), typeof(int), typeof(bool) },
+    new ArgumentType[] { ArgumentType.Normal, ArgumentType.Ref, ArgumentType.Normal })]
+static class Patch_PopulateWithPlanets
 {
-    static void Postfix(bool getAll, ref List<TransferObject> __result)
+    static void Postfix(Span<TransferObject> list, ref int count, bool getAll)
     {
         if (getAll) return;
 
@@ -27,17 +29,20 @@ static class Patch_GetPlanetList
             if (star == null) return;
 
             var existingIds = new HashSet<string>();
-            foreach (var entry in __result)
-                if (entry.Body != null)
-                    existingIds.Add(entry.Body.Id);
-
-            foreach (Astronomical astro in Universe.CurrentSystem!.All.GetList())
+            for (int i = 0; i < count; i++)
             {
-                if (astro is not Celestial celestial) continue;
-                if (astro is StellarBody) continue;
-                if (celestial.Orbit == null || celestial.Orbit.Eccentricity < 1.0) continue;
-                if (existingIds.Contains(celestial.Id)) continue;
+                Astronomical? body = list[i].Body;
+                if (body != null)
+                    existingIds.Add(body.Id);
+            }
 
+            ReadOnlySpan<Astronomical> all = Universe.CurrentSystem!.All.AsSpan();
+            for (int i = 0; i < all.Length; i++)
+            {
+                if (all[i] is not Celestial celestial) continue;
+                if (celestial.Orbit == null || celestial.Orbit.Eccentricity < 1.0) continue;
+                if (celestial.Id == source.Id || celestial.Id == source.Parent?.Id) continue;
+                if (existingIds.Contains(celestial.Id)) continue;
                 if (celestial.Parent != star) continue;
 
                 if (celestial.SphereOfInfluence <= 0.0 || double.IsNaN(celestial.SphereOfInfluence))
@@ -47,12 +52,13 @@ static class Patch_GetPlanetList
                     continue;
                 }
 
-                __result.Add(new TransferObject(celestial));
+                if (count >= list.Length) break;
+                list[count++] = new TransferObject(celestial);
             }
         }
         catch (Exception ex)
         {
-            DefaultCategory.Log.Warning($"[AFC] GetPlanetList postfix: {ex.Message}");
+            DefaultCategory.Log.Warning($"[AFC] PopulateWithPlanets postfix: {ex.Message}");
         }
     }
 }
@@ -132,12 +138,11 @@ static class Patch_SetTransferInfo
                 as List<TimeObject>;
             if (timeUnits == null) return;
 
+            Span<char> buf = stackalloc char[64];
             foreach (var unit in timeUnits)
             {
-                string formatted = TimeSpanReference
-                    .FromSeconds(hohmann.Seconds())
-                    .ToNearest(unit.Unit);
-                int wholeDigits = formatted.IndexOfAny(['.', ' ']);
+                Span<char> formatted = TimeSpanReference.ToNearest(unit.Unit, hohmann.Seconds(), buf);
+                int wholeDigits = formatted.IndexOfAny('.', ' ');
                 if (wholeDigits < 0) wholeDigits = formatted.Length;
                 if (wholeDigits <= 3)
                 {

--- a/AdvancedFlightComputer/Patches/HyperbolicBodies.xml
+++ b/AdvancedFlightComputer/Patches/HyperbolicBodies.xml
@@ -1,33 +1,20 @@
 <Patch>
   <!--
-    Adds Mass and SphereOfInfluence to hyperbolic interstellar objects.
-
-    Mass: Estimated from MeanRadius assuming 1000 kg/m^3 density (rocky/icy mix).
-    The exact value barely matters - at 50+ km/s flyby velocity, gravitational
-    deflection is negligible regardless.
-
-    SphereOfInfluence: Artificial detection radius. The Hill sphere formula
-    (0.9431 * SMA * (m/M)^0.4) produces negative values for hyperbolic orbits
-    because SMA is negative. Setting SOI explicitly bypasses that formula entirely.
-    50,000 km is large enough for the game's encounter detection to work reliably
-    during the RefineBurnTask +/-5% dV sweep.
+    Interstellar comets need Mass and SphereOfInfluence to be targetable
+    by the Transfer Planner.
   -->
 
-  <!-- Oumuamua: r=100m, mass ~ 4.19 Gg (defined in SolSystem.xml) -->
-  <Copy Path="//Comet[@Id='Oumuamua']" Pos="Append">
+  <Copy Path="//InterstellarComet[@Id='Oumuamua']" Pos="Append">
     <Mass Gg="4.19" />
     <SphereOfInfluence Km="50000" />
   </Copy>
 
-  <!-- 2I/Borisov: r=500m, mass ~ 524 Gg (defined in Astronomicals.xml) -->
-  <Copy Path="//Comet[@Id='Borisov']" Pos="Append">
+  <Copy Path="//InterstellarComet[@Id='Borisov']" Pos="Append">
     <Mass Gg="524" />
     <SphereOfInfluence Km="50000" />
   </Copy>
 
-  <!-- 3I/ATLAS: r=500m, mass ~ 524 Gg (defined in Astronomicals.xml) -->
-  <Copy Path="//Comet[@Id='3I_ATLAS']" Pos="Append">
-    <Mass Gg="524" />
+  <Copy Path="//InterstellarComet[@Id='3I_ATLAS']" Pos="Append">
     <SphereOfInfluence Km="50000" />
   </Copy>
 </Patch>


### PR DESCRIPTION
- Patch_GetPlanetList -> Patch_PopulateWithPlanets (renamed, Span-based signature)
- Self-target guard, drop unreachable StellarBody check
- SetTransferInfo uses the Span<char> ToNearest overload
- XML XPath to //InterstellarComet, 3I_ATLAS Mass ships stock

Branch only covers HyperbolicTargets; other features still fail to build and will be addressed separately.