### PR TITLE
Update ManeuverTools for KSA v2026.4.16.4170

### DIFF
--- a/AdvancedFlightComputer/Features/ManeuverTools/DrawPlanWindowPatch.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/DrawPlanWindowPatch.cs
@@ -162,11 +162,11 @@ static class Patch_DrawPlanWindow
     private static Vehicle? DrawSourceDropdown()
     {
         var sourceBody = (TransferObject)GameReflection.TransferPlanner_sourceBody!.GetValue(null)!;
-        int currentCount = Universe.CurrentSystem!.Vehicles.GetList().Count;
+        int currentCount = Universe.CurrentSystem!.CountOf<Vehicle>();
         if (_vehicleList == null || currentCount != _lastVehicleCount)
         {
             _vehicleList = new List<TransferObject>();
-            foreach (Vehicle v in Universe.CurrentSystem.Vehicles.GetList())
+            foreach (Vehicle v in Universe.CurrentSystem.All.OfType<Vehicle>())
                 _vehicleList.Add(new TransferObject(v));
             _lastVehicleCount = currentCount;
         }
@@ -341,7 +341,8 @@ static class Patch_DrawPlanWindow
         {
             return OrbitManeuvers.ComputeSetInclination(
                 orbit, ManeuverToolsWindow.TargetInclinationRad,
-                ManeuverToolsWindow.UseDescendingNode, now);
+                ManeuverToolsWindow.UseDescendingNode, now,
+                ManeuverToolsWindow.InclinationRef);
         }
 
         return null;

--- a/AdvancedFlightComputer/Features/ManeuverTools/ManeuverToolsWindow.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/ManeuverToolsWindow.cs
@@ -26,8 +26,12 @@ static class ManeuverToolsWindow
     public static double TargetAltitude;
     public static bool UseDescendingNode;
     public static double TargetInclinationRad;
+    public static OrbitManeuvers.InclinationReference InclinationRef =
+        OrbitManeuvers.InclinationReference.Equatorial;
 
     #endregion
+
+    private static readonly string[] InclinationRefLabels = { "Ecliptic", "Equatorial" };
 
     #region Internal State
 
@@ -232,7 +236,32 @@ static class ManeuverToolsWindow
     {
         Orbit orbit = source.Orbit;
         SimTime now = Universe.GetElapsedSimTime();
-        double currentIncDeg = orbit.Inclination * (180.0 / Math.PI);
+
+        ImGui.Text("Reference Plane:");
+        ImGui.SameLine(220f);
+        ImGui.PushItemWidth(-1f);
+        int refIdx = (int)InclinationRef;
+        if (ImGui.BeginCombo("##incRef"u8, InclinationRefLabels[refIdx]))
+        {
+            for (int i = 0; i < InclinationRefLabels.Length; i++)
+            {
+                bool isSelected = i == refIdx;
+                if (ImGui.Selectable(InclinationRefLabels[i], isSelected))
+                {
+                    var newRef = (OrbitManeuvers.InclinationReference)i;
+                    if (newRef != InclinationRef)
+                    {
+                        InclinationRef = newRef;
+                        _defaultsInitialized = false;
+                    }
+                }
+            }
+            ImGui.EndCombo();
+        }
+        ImGui.PopItemWidth();
+
+        double currentIncDeg = OrbitManeuvers.GetInclinationAgainst(orbit, InclinationRef)
+            * (180.0 / Math.PI);
 
         if (!_defaultsInitialized)
         {
@@ -240,11 +269,11 @@ static class ManeuverToolsWindow
             _defaultsInitialized = true;
         }
 
-        ImGui.Text("Target Inclination (deg):");
+        ImGui.Text("Target Inclination:");
         ImGui.SameLine(220f);
         ImGui.PushItemWidth(-1f);
         ImGui.InputDouble("##incInput"u8, ref _inputInclinationDeg, 1.0, 10.0,
-            default(ImString), ImGuiInputTextFlags.CharsDecimal);
+            "%.2f"u8, ImGuiInputTextFlags.CharsDecimal);
         _inputInclinationDeg = Math.Clamp(_inputInclinationDeg, 0.0, 180.0);
         ImGui.PopItemWidth();
         TargetInclinationRad = _inputInclinationDeg * (Math.PI / 180.0);
@@ -262,10 +291,12 @@ static class ManeuverToolsWindow
             return;
         }
 
-        var (_, _, anTime, dnTime) = OrbitManeuvers.GetEquatorialNodes(orbit, now);
+        var (_, _, anTime, dnTime) = OrbitManeuvers.GetReferenceNodes(orbit, now, InclinationRef);
 
-        var anResult = OrbitManeuvers.ComputeSetInclination(orbit, TargetInclinationRad, false, now);
-        var dnResult = OrbitManeuvers.ComputeSetInclination(orbit, TargetInclinationRad, true, now);
+        var anResult = OrbitManeuvers.ComputeSetInclination(
+            orbit, TargetInclinationRad, false, now, InclinationRef);
+        var dnResult = OrbitManeuvers.ComputeSetInclination(
+            orbit, TargetInclinationRad, true, now, InclinationRef);
 
         DrawNodeSelection(orbit, anTime, dnTime, anResult, dnResult);
     }
@@ -321,7 +352,7 @@ static class ManeuverToolsWindow
 
     private static void DrawTargetSelector(Vehicle source)
     {
-        int currentCount = Universe.CurrentSystem?.All.GetList().Count ?? 0;
+        int currentCount = Universe.CurrentSystem?.All.Count ?? 0;
         if (_targetList == null || currentCount != _lastObjectCount)
         {
             _targetList = BuildTargetList(source);
@@ -354,7 +385,7 @@ static class ManeuverToolsWindow
         if (parent == null || Universe.CurrentSystem == null)
             return list;
 
-        foreach (Astronomical astro in Universe.CurrentSystem.All.GetList())
+        foreach (Astronomical astro in Universe.CurrentSystem.All.AsSpan())
         {
             if (astro == source) continue;
             if (astro is StellarBody) continue;
@@ -403,7 +434,7 @@ static class ManeuverToolsWindow
         ImGui.SameLine(220f);
         ImGui.PushItemWidth(-1f);
         ImGui.InputDouble("##altInput"u8, ref _inputAltitudeKm, 10.0, 100.0,
-            default(ImString), ImGuiInputTextFlags.CharsDecimal);
+            "%.2f"u8, ImGuiInputTextFlags.CharsDecimal);
         if (_inputAltitudeKm < 0.0)
             _inputAltitudeKm = 0.0;
         ImGui.PopItemWidth();

--- a/AdvancedFlightComputer/Features/ManeuverTools/OrbitManeuvers.cs
+++ b/AdvancedFlightComputer/Features/ManeuverTools/OrbitManeuvers.cs
@@ -14,6 +14,34 @@ static class OrbitManeuvers
     public record struct ManeuverResult(double3 DvCci, double3 DvVlf, SimTime BurnTime);
 
     /// <summary>
+    /// Reference plane for inclination measurement.
+    /// </summary>
+    public enum InclinationReference { Ecliptic, Equatorial }
+
+    /// <summary>
+    /// Returns the reference plane normal in the CCI frame for the given orbit.
+    /// CCI Z-axis is the ecliptic normal in KSA; the equatorial normal is the
+    /// parent body's rotation axis (CCE Z-axis transformed to CCI).
+    /// </summary>
+    public static double3 GetReferenceNormalCci(Orbit orbit, InclinationReference reference)
+    {
+        if (reference == InclinationReference.Ecliptic)
+            return double3.UnitZ;
+        return double3.UnitZ.Transform(orbit.Parent.GetCce2Cci());
+    }
+
+    /// <summary>
+    /// Returns the orbit's inclination relative to the chosen reference plane.
+    /// For Ecliptic this equals Orbit.Inclination.
+    /// </summary>
+    public static double GetInclinationAgainst(Orbit orbit, InclinationReference reference)
+    {
+        double3 referenceNormal = GetReferenceNormalCci(orbit, reference);
+        double3 orbitNormal = orbit.GetOrbitNormalCci();
+        return MathEx.SafeAcos(double3.Dot(referenceNormal, orbitNormal));
+    }
+
+    /// <summary>
     /// Computes a prograde/retrograde burn at the next apoapsis to set periapsis
     /// to a target altitude above the parent body's surface.
     /// </summary>
@@ -121,26 +149,26 @@ static class OrbitManeuvers
 
     /// <summary>
     /// Computes a plane-change burn at the ascending or descending node (relative
-    /// to the parent body's equatorial plane) to set the orbit's inclination to
-    /// a specific angle. Preserves orbital speed and LAN.
+    /// to the chosen reference plane) to set the orbit's inclination to a specific
+    /// angle. Preserves orbital speed.
     /// </summary>
     public static ManeuverResult? ComputeSetInclination(
-        Orbit orbit, double targetInclinationRad, bool useDescendingNode, SimTime now)
+        Orbit orbit, double targetInclinationRad, bool useDescendingNode, SimTime now,
+        InclinationReference reference)
     {
         targetInclinationRad = Math.Clamp(targetInclinationRad, 0.0, Math.PI);
 
-        double currentInc = orbit.Inclination;
+        double currentInc = GetInclinationAgainst(orbit, reference);
         double incDiff = Math.Abs(targetInclinationRad - currentInc);
         if (incDiff < 0.001)
             return null;
 
         double3 vehicleNormal = orbit.GetOrbitNormalCci();
-        double3 equatorialNormal = new double3(0, 0, 1);
+        double3 referenceNormal = GetReferenceNormalCci(orbit, reference);
 
-        // AN/DN relative to equatorial plane
-        double3 nodeDir = double3.Cross(equatorialNormal, vehicleNormal).NormalizeOrZero();
+        double3 nodeDir = double3.Cross(referenceNormal, vehicleNormal).NormalizeOrZero();
         if (nodeDir.LengthSquared() < 1e-12)
-            nodeDir = new double3(1, 0, 0); // fallback for equatorial orbits
+            nodeDir = new double3(1, 0, 0); // fallback for coplanar orbits
 
         TrueAnomaly anTa = orbit.GetTrueAnomaly(nodeDir);
         TrueAnomaly nodeTa = useDescendingNode
@@ -150,12 +178,11 @@ static class OrbitManeuvers
         SimTime nodeTime = orbit.TimeOfTrueAnomaly(nodeTa, now);
         StateVectors sv = orbit.GetStateVectorsAt(nodeTime);
 
-        // Target normal: same LAN, new inclination
-        double lan = orbit.LongitudeOfAscendingNode;
-        double3 targetNormal = new double3(
-            Math.Sin(targetInclinationRad) * Math.Sin(lan),
-            -Math.Sin(targetInclinationRad) * Math.Cos(lan),
-            Math.Cos(targetInclinationRad));
+        // Target normal: rotate reference normal around the node line by target
+        // inclination. This preserves the AN/DN line and sets the inclination
+        // relative to the reference plane directly.
+        doubleQuat tilt = QuaternionEx.AngleAxis(targetInclinationRad, nodeDir);
+        double3 targetNormal = referenceNormal.Transform(tilt);
 
         double3 rotAxis = double3.Cross(vehicleNormal, targetNormal).NormalizeOrZero();
         if (rotAxis.LengthSquared() < 1e-12)
@@ -171,15 +198,15 @@ static class OrbitManeuvers
     }
 
     /// <summary>
-    /// Computes AN/DN true anomalies and times relative to the equatorial plane.
-    /// Used by the UI to display both node options for Set Inclination.
+    /// Computes AN/DN true anomalies and times relative to the chosen reference
+    /// plane. Used by the UI to display both node options for Set Inclination.
     /// </summary>
     public static (TrueAnomaly anTa, TrueAnomaly dnTa, SimTime anTime, SimTime dnTime)
-        GetEquatorialNodes(Orbit orbit, SimTime now)
+        GetReferenceNodes(Orbit orbit, SimTime now, InclinationReference reference)
     {
         double3 vehicleNormal = orbit.GetOrbitNormalCci();
-        double3 equatorialNormal = new double3(0, 0, 1);
-        double3 nodeDir = double3.Cross(equatorialNormal, vehicleNormal).NormalizeOrZero();
+        double3 referenceNormal = GetReferenceNormalCci(orbit, reference);
+        double3 nodeDir = double3.Cross(referenceNormal, vehicleNormal).NormalizeOrZero();
 
         if (nodeDir.LengthSquared() < 1e-12)
             nodeDir = new double3(1, 0, 0);


### PR DESCRIPTION
- Migrate to the new API (All.AsSpan/Count, CountOf<Vehicle>, OfType<Vehicle>)
- Fix Set Inclination reference plane: Ecliptic/Equatorial dropdown, rotate around the node line (closes #26)
- Shorter input label, 2-decimal format